### PR TITLE
Check which variables on_pre and on_post statements refer to

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -48,6 +48,24 @@ prefs['codegen.loop_invariant_optimisations'] = False
 prefs['core.network.default_schedule']= ['start', 'synapses', 'groups', 'thresholds', 'resets', 'end']
 
 
+def stringify(code):
+    '''
+    Helper function to prepare multiline strings (potentially including
+    quotation marks) to be included in strings.
+
+    Examples
+    --------
+    >>> print(stringify('v = 0*mV;\nv_th += 3*mV;'))
+    v = 0*mV;\n\
+    v_th += 3*mV;
+    >>> print(stringify('name = "foo";'))
+    name = \"foo\";
+    '''
+    code = code.replace('\n', '\\n\\\n')
+    code = code.replace('"', '\\"')
+    return code
+
+
 def freeze(code, ns):
     '''
     Support function for substituting constant values.
@@ -84,10 +102,9 @@ def decorate(code, variables, parameters, do_final= True):
         code = word_substitute(code, {v : '$('+v+')'})
     for p in parameters:
         code = word_substitute(code, {p : '$('+p+')'})
-    code= word_substitute(code, {'dt' : 'DT'}).strip()
+    code = word_substitute(code, {'dt' : 'DT'}).strip()
     if do_final: 
-        code= code.replace('\n', '\\n\\\n')
-        code = code.replace('"', '\\"')
+        code = stringify(code)
         code = word_substitute(code, {'addtoinSyn' : '$(addtoinSyn)'})
         code = word_substitute(code, {'_hidden_weightmatrix' : '$(_hidden_weightmatrix)'})
     return code
@@ -149,11 +166,11 @@ class synapseModel(object):
         self.external_variables = []
         self.parameters = []
         self.pvalue = []
-        self.simCode = defaultdict(str)
-        self.synapseDynamics = []
         self.postSyntoCurrent = []
+        # The following dictionaries contain keys "pre"/"post" for the pre-
+        # and post-synaptic pathway and "dynamics" for the synaptic dynamics
+        self.main_code_lines = defaultdict(str)
         self.support_code_lines = defaultdict(str)
-        self.dyn_support_code_lines = []
         self.connectivity = ''
         self.delay = 0
 
@@ -435,7 +452,7 @@ class GeNNDevice(CPPStandaloneDevice):
         if '_brian_mod' in code:
             code= code.replace('_brian_mod','fmod')
             
-        return model, code
+        return code
 
     #---------------------------------------------------------------------------------
     def build(self, directory='GeNNworkspace', compile=True, run=True, use_GPU=True,
@@ -679,6 +696,24 @@ class GeNNDevice(CPPStandaloneDevice):
                     call(["make", "clean"], cwd=directory)
                     call(["make"], cwd=directory)
 
+    def add_parameter(self, model, varname, variable):
+        model.parameters.append(varname)
+        model.pvalue.append(repr(variable.value))
+
+    def add_array_variable(self, model, varname, variable):
+        model.variables.append(varname)
+        model.variabletypes.append(c_data_type(variable.dtype))
+        model.variablescope[varname] = 'brian'
+
+    def add_array_variables(self, model, owner):
+        for varname, variable in owner.variables.iteritems():
+            if varname in ['_spikespace', 't', 'dt']:
+                pass
+            elif getattr(variable.owner, 'name', None) != owner.name:
+                pass
+            elif isinstance(variable, ArrayVariable):
+                self.add_array_variable(model, varname, variable)
+
     def process_poisson_groups(self, objects, poisson_groups):
         for obj in poisson_groups:
             # throw error if events other than spikes are used
@@ -691,13 +726,7 @@ class GeNNDevice(CPPStandaloneDevice):
             neuron_model = neuronModel()
             neuron_model.name = obj.name
             neuron_model.N = obj.N
-            for k, v in obj.variables.iteritems():
-                if k == '_spikespace' or k == 't' or k == 'dt':
-                    pass
-                elif isinstance(v, ArrayVariable):
-                    neuron_model.variables.append(k)
-                    neuron_model.variabletypes.append(c_data_type(v.dtype))
-                    neuron_model.variablescope[k] = 'brian'
+            self.add_array_variables(neuron_model, obj)
             support_lines = []
             suffix = '_thresholder';
             lines = neuron_model.thresh_cond_lines;
@@ -705,17 +734,14 @@ class GeNNDevice(CPPStandaloneDevice):
             for k, v in codeobj.variables.iteritems():
                 if k != 'dt' and isinstance(v, Constant):
                     if k not in neuron_model.parameters:
-                        neuron_model.parameters.append(k)
-                        neuron_model.pvalue.append(repr(v.value))
+                        self.add_parameter(neuron_model, k, v)
                 code = codeobj.code.cpp_file
 
-            neuron_model, code = self.fix_random_generators(neuron_model, code)
+            code = self.fix_random_generators(neuron_model, code)
             code = decorate(code, neuron_model.variables,
                             neuron_model.parameters).strip()
             lines.append(code)
-            code = codeobj.code.h_file
-            code = code.replace('\n', '\\n\\\n')
-            code = code.replace('"', '\\"')
+            code = stringify(codeobj.code.h_file)
             support_lines.append(code)
             neuron_model.support_code_lines = support_lines
             self.neuron_models.append(neuron_model)
@@ -732,16 +758,7 @@ class GeNNDevice(CPPStandaloneDevice):
             neuron_model = neuronModel()
             neuron_model.name = obj.name
             neuron_model.N = obj.N
-            for k, v in obj.variables.iteritems():
-                if k == '_spikespace' or k == 't' or k == 'dt':
-                    pass
-                # Do not add variables that are references
-                if getattr(v.owner, 'name', None) != obj.name:
-                    pass
-                elif isinstance(v, ArrayVariable):
-                    neuron_model.variables.append(k)
-                    neuron_model.variabletypes.append(c_data_type(v.dtype))
-                    neuron_model.variablescope[k] = 'brian'
+            self.add_array_variables(neuron_model, obj)
             support_lines = []
             for suffix, lines in [('_stateupdater', neuron_model.code_lines),
                                   ('_run_regularly', neuron_model.code_lines),
@@ -768,20 +785,16 @@ class GeNNDevice(CPPStandaloneDevice):
                 for k, v in codeobj.variables.iteritems():
                     if k != 'dt' and isinstance(v, Constant):
                         if k not in neuron_model.parameters:
-                            neuron_model.parameters.append(k)
-                            neuron_model.pvalue.append(repr(v.value))
+                            self.add_parameter(neuron_model, k, v)
                 code = codeobj.code.cpp_file
 
                 if (suffix == '_resetter') and not (obj._refractory is False):
                     code = code + '\n lastspike = t; \n not_refractory= 0;'
-                neuron_model, code = self.fix_random_generators(neuron_model,
-                                                                code)
+                code = self.fix_random_generators(neuron_model, code)
                 code = decorate(code, neuron_model.variables,
                                 neuron_model.parameters).strip()
                 lines.append(code)
-                code = codeobj.code.h_file
-                code = code.replace('\n', '\\n\\\n')
-                code = code.replace('"', '\\"')
+                code = stringify(codeobj.code.h_file)
                 support_lines.append(code)
             neuron_model.support_code_lines = support_lines
             self.neuron_models.append(neuron_model)
@@ -824,29 +837,7 @@ class GeNNDevice(CPPStandaloneDevice):
                     if pathway == 'pre' and 'not_refractory' in codeobj.variables:
                         codeobj.variables['not_refractory_post'] = codeobj.variables['not_refractory']
                         del codeobj.variables['not_refractory']
-                    for k, v in codeobj.variables.iteritems():
-                        if k == '_spikespace' or k == 't' or k == 'dt':
-                            pass
-                        elif isinstance(v, Constant):
-                            if k not in synapse_model.parameters:
-                                synapse_model.parameters.append(k)
-                                synapse_model.pvalue.append(repr(v.value))
-                        elif isinstance(v, ArrayVariable):
-                            if k in codeobj.code.__str__():
-                                if '_pre' not in k and '_post' not in k:
-                                    if k not in synapse_model.variables:
-                                        if codeobj.variable_indices[k] == '_idx':
-                                            synapse_model.variables.append(k)
-                                            synapse_model.variabletypes.append(
-                                                c_data_type(v.dtype))
-                                            synapse_model.variablescope[k] = 'brian'
-                                else:
-                                    if k not in synapse_model.external_variables:
-                                        synapse_model.external_variables.append(k)
-                        elif isinstance(v, Subexpression):
-                            raise NotImplementedError(
-                                'Brian2genn does not support the use of '
-                                'subexpressions in synaptic statements')
+                    self.collect_synapses_variables(synapse_model, codeobj)
                     if pathway == 'pre':
                         # Use the stored scalar delay (if any) for these synapses
                         synapse_model.delay = int(
@@ -864,54 +855,16 @@ class GeNNDevice(CPPStandaloneDevice):
                             if line.startswith('addtoinSyn'):
                                 new_code_lines.append('$(updatelinsyn);')
                         code = '\n'.join(new_code_lines)
-                    if synapse_model.connectivity == 'DENSE':
-                        code = 'if (_hidden_weightmatrix != 0.0) {' + code + '}'
-                    synapse_model, code = self.fix_random_generators(synapse_model,
-                                                                     code)
-                    thecode = decorate(code, synapse_model.variables,
-                                       synapse_model.parameters, False).strip()
-                    thecode = decorate(thecode, synapse_model.external_variables,
-                                       [], True).strip()
-                    synapse_model.simCode[pathway] = thecode
-                    code = codeobj.code.h_file
-                    code = code.replace('\n', '\\n\\\n')
-                    code = code.replace('"', '\\"')
-                    synapse_model.support_code_lines[pathway] = code
+
+                    self.fix_synapses_code(synapse_model, pathway, codeobj,
+                                           code)
 
             if obj.state_updater != None:
                 codeobj = obj.state_updater.codeobj
                 code = codeobj.code.cpp_file
-                for k, v in codeobj.variables.iteritems():
-                    if k == '_spikespace' or k == 't' or k == 'dt':
-                        pass
-                    elif isinstance(v, Constant):
-                        if k not in synapse_model.parameters:
-                            synapse_model.parameters.append(k)
-                            synapse_model.pvalue.append(repr(v.value))
-                    elif isinstance(v, ArrayVariable):
-                        if k in codeobj.code.__str__():
-                            if '_pre' not in k and '_post' not in k:
-                                if k not in synapse_model.variables:
-                                    synapse_model.variables.append(k)
-                                    synapse_model.variabletypes.append(
-                                        c_data_type(v.dtype))
-                                    synapse_model.variablescope[k] = 'brian'
-                            else:
-                                if k not in synapse_model.external_variables:
-                                    synapse_model.external_variables.append(k)
-                if synapse_model.connectivity == 'DENSE':
-                    code = 'if (_hidden_weightmatrix != 0.0) {' + code + '}'
-                synapse_model, code = self.fix_random_generators(synapse_model,
-                                                                 code)
-                thecode = decorate(code, synapse_model.variables,
-                                   synapse_model.parameters, False).strip()
-                thecode = decorate(thecode, synapse_model.external_variables,
-                                   [], True).strip()
-                synapse_model.synapseDynamics = thecode
-                code = codeobj.code.h_file
-                code = code.replace('\n', '\\n\\\n')
-                code = code.replace('"', '\\"')
-                synapse_model.dyn_support_code_lines = code
+                self.collect_synapses_variables(synapse_model, codeobj)
+                self.fix_synapses_code(synapse_model, 'dynamics', codeobj,
+                                       code)
 
             if (hasattr(obj, '_genn_post_write_var')):
                 synapse_model.postSyntoCurrent = '0; $(' + obj._genn_post_write_var.replace(
@@ -920,6 +873,39 @@ class GeNNDevice(CPPStandaloneDevice):
                 synapse_model.postSyntoCurrent = '0'
             self.synapse_models.append(synapse_model)
             self.groupDict[synapse_model.name] = synapse_model
+
+    def collect_synapses_variables(self, synapse_model, codeobj):
+        for k, v in codeobj.variables.iteritems():
+            if k in ['_spikespace', 't', 'dt']:
+                pass
+            elif isinstance(v, Constant):
+                if k not in synapse_model.parameters:
+                    self.add_parameter(synapse_model, k, v)
+            elif isinstance(v, ArrayVariable):
+                if k in codeobj.code.__str__():
+                    if '_pre' not in k and '_post' not in k:
+                        if k not in synapse_model.variables:
+                            self.add_array_variable(synapse_model, k, v)
+                    else:
+                        if k not in synapse_model.external_variables:
+                            synapse_model.external_variables.append(k)
+            elif isinstance(v, Subexpression):
+                raise NotImplementedError(
+                    'Brian2genn does not support the use of '
+                    'subexpressions in synaptic statements')
+
+
+    def fix_synapses_code(self, synapse_model, pathway, codeobj, code):
+        if synapse_model.connectivity == 'DENSE':
+            code = 'if (_hidden_weightmatrix != 0.0) {' + code + '}'
+        code = self.fix_random_generators(synapse_model, code)
+        thecode = decorate(code, synapse_model.variables,
+                           synapse_model.parameters, False).strip()
+        thecode = decorate(thecode, synapse_model.external_variables,
+                           [], True).strip()
+        synapse_model.main_code_lines[pathway] = thecode
+        code = stringify(codeobj.code.h_file)
+        synapse_model.support_code_lines[pathway] = code
 
     def process_spike_monitors(self, spike_monitors):
         for obj in spike_monitors:

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -27,6 +27,7 @@ from brian2.monitors.ratemonitor import PopulationRateMonitor
 from brian2.monitors.statemonitor import StateMonitor
 from brian2.utils.filetools import copy_directory, ensure_directory
 from brian2.utils.stringtools import word_substitute, get_identifiers
+from brian2.groups.group import Group
 from brian2.groups.neurongroup import NeuronGroup, StateUpdater, Resetter, Thresholder
 from brian2.groups.subgroup import Subgroup
 from brian2.input.poissongroup import PoissonGroup
@@ -624,6 +625,30 @@ class GeNNDevice(CPPStandaloneDevice):
             os.path.join(directory, 'results/last_run_info.txt'), 'r').read()
         self._last_run_time, self._last_run_completed_fraction = map(float,
                                                                      last_run_info.split())
+
+        # The following is a verbatim copy of the respective code in
+        # CPPStandaloneDevice.run. In the long run, we can hopefully implement
+        # this on the device-independent level, see #761 and discussion in
+        # #750.
+
+        # Make sure that integration did not create NaN or very large values
+        owners = [var.owner for var in self.arrays]
+        # We don't want to check the same owner twice but var.owner is a
+        # weakproxy which we can't put into a set. We therefore store the name
+        # of all objects we already checked. Furthermore, under some specific
+        # instances a variable might have been created whose owner no longer
+        # exists (e.g. a `_sub_idx` variable for a subgroup) -- we ignore the
+        # resulting reference error.
+        already_checked = set()
+        for owner in owners:
+            try:
+                if owner.name in already_checked:
+                    continue
+                if isinstance(owner, Group):
+                    owner._check_for_invalid_states()
+                    already_checked.add(owner.name)
+            except ReferenceError:
+                pass
 
     def compile_source(self, debug, directory, use_GPU):
         with std_silent(debug):

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -131,12 +131,12 @@ void modelDefinition(NNmodel &model)
   s.pNames.push_back("{{par}}");
   {% endfor %}
   // step 3: add simcode
-  s.simCode= "{% for line in synapse_model.simCode['pre'] %}{{line}}{% endfor %}";
-  s.simLearnPost= "{% for line in synapse_model.simCode['post'] %}{{line}}{% endfor %}";
-  s.synapseDynamics= "{% for line in synapse_model.synapseDynamics %}{{line}}{% endfor %}";  
+  s.simCode= "{% for line in synapse_model.main_code_lines['pre'] %}{{line}}{% endfor %}";
+  s.simLearnPost= "{% for line in synapse_model.main_code_lines['post'] %}{{line}}{% endfor %}";
+  s.synapseDynamics= "{% for line in synapse_model.main_code_lines['dynamics'] %}{{line}}{% endfor %}";
   s.simCode_supportCode= "{% for line in synapse_model.support_code_lines['pre'] %}{{line}}{% endfor %}";
   s.simLearnPost_supportCode= "{% for line in synapse_model.support_code_lines['post'] %}{{line}}{% endfor %}";
-  s.synapseDynamics_supportCode= "{% for line in synapse_model.dyn_support_code_lines %}{{line}}{% endfor %}";
+  s.synapseDynamics_supportCode= "{% for line in synapse_model.support_code_lines['dynamics'] %}{{line}}{% endfor %}";
   weightUpdateModels.push_back(s);
   {{synapse_model.name}}WEIGHTUPDATE= weightUpdateModels.size()-1;
   // post-synaptic model

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -131,12 +131,12 @@ void modelDefinition(NNmodel &model)
   s.pNames.push_back("{{par}}");
   {% endfor %}
   // step 3: add simcode
-  s.simCode= "{% for line in synapse_model.simCode %}{{line}}{% endfor %}";
-  s.simLearnPost= "{% for line in synapse_model.simLearnPost %}{{line}}{% endfor %}";
+  s.simCode= "{% for line in synapse_model.simCode['pre'] %}{{line}}{% endfor %}";
+  s.simLearnPost= "{% for line in synapse_model.simCode['post'] %}{{line}}{% endfor %}";
   s.synapseDynamics= "{% for line in synapse_model.synapseDynamics %}{{line}}{% endfor %}";  
-  s.simCode_supportCode= "{% for line in synapse_model.pre_support_code_lines %}{{line}}{% endfor %}";  
-   s.simLearnPost_supportCode= "{% for line in synapse_model.post_support_code_lines %}{{line}}{% endfor %}";  
-   s.synapseDynamics_supportCode= "{% for line in synapse_model.dyn_support_code_lines %}{{line}}{% endfor %}";  
+  s.simCode_supportCode= "{% for line in synapse_model.support_code_lines['pre'] %}{{line}}{% endfor %}";
+  s.simLearnPost_supportCode= "{% for line in synapse_model.support_code_lines['post'] %}{{line}}{% endfor %}";
+  s.synapseDynamics_supportCode= "{% for line in synapse_model.dyn_support_code_lines %}{{line}}{% endfor %}";
   weightUpdateModels.push_back(s);
   {{synapse_model.name}}WEIGHTUPDATE= weightUpdateModels.size()-1;
   // post-synaptic model


### PR DESCRIPTION
This fixes #28 by raising a `NotImplementedError` when an `on_pre` statement refers to a pre-synaptic variable or an `on_post` statement refers to a post-synaptic variable. This is actually more restrictive than necessary, since *reading* such a variable should be fine, but checking for that would be more complicated. What do you think, is this important for a first version of `brian2genn`? There are certainly models where the synaptic effect depends on some pre-synaptic variable, but for those we'd also need to figure out how to deal with the different semantics between Brian and GeNN related to delays (Brian would use the value at the time of the synaptic action, GeNN at the time of the pre-synaptic spike).

This PR also refactors a bit of code to remove redundancies and is built on top of #29, so it should be merged after that.