### PR TITLE
Doc fixes

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -53,13 +53,10 @@ def stringify(code):
     Helper function to prepare multiline strings (potentially including
     quotation marks) to be included in strings.
 
-    Examples
-    --------
-    >>> print(stringify('v = 0*mV;\nv_th += 3*mV;'))
-    v = 0*mV;\n\
-    v_th += 3*mV;
-    >>> print(stringify('name = "foo";'))
-    name = \"foo\";
+    Parameters
+    ----------
+    code : str
+        The code to convert.
     '''
     code = code.replace('\n', '\\n\\\n')
     code = code.replace('"', '\\"')

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name='Brian2GeNN',
 #                        'pyparsing',
                         'jinja2>=2.7',
                         'setuptools>=6.0',  # FIXME: setuptools>=6.0 is only needed for Windows
-                        'brian2'
+                        'brian2>=2.0'
                        ],
       setup_requires=[
 #'numpy>=1.8.0',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(name='Brian2GeNN',
                         'setuptools>=6.0',  # FIXME: setuptools>=6.0 is only needed for Windows
                         'brian2'
                        ],
-      dependency_links=["https://github.com/brian-team/brian2/tarball/fd3afff2be7b506d8aa76e6fd2259f888fa40ba0#egg=brian2-2.0b4"],
       setup_requires=[
 #'numpy>=1.8.0',
                       'setuptools>=6.0'


### PR DESCRIPTION
Brian2genn still had a hard-coded reference to a specific Brian 2 version in setup.py, but its current version now needs the final 2.0 release. This is why the readthedocs build failed (which is a nice replacement for an actual continuous integration testing service :) ). Removing this reference and depending on `brian2>=2.0` should fix the issue.