### PR TITLE
Use Brian's general compiler preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@ brian2genn
 ==========
 
 Brian 2 frontend to the GeNN simulator
+
+Please note that this package is still under development and has not
+yet been officially released. It currently requires the latest version
+of GeNN from its master branch (see https://github.com/genn-team/genn).

--- a/brian2genn/correctness_testing.py
+++ b/brian2genn/correctness_testing.py
@@ -1,5 +1,5 @@
 '''
-Definitions of theconfiguration for correctness testing.
+Definitions of the configuration for correctness testing.
 '''
 import brian2
 import os
@@ -16,21 +16,20 @@ __all__ = ['GeNNConfiguration',
 class GeNNConfiguration(Configuration):
     name = 'GeNN'
     def before_run(self):
-        brian2.prefs.devices.genn.unix_compiler_flags=''
-        brian2.prefs.devices.genn.windows_compiler_flags=''
+        brian2.prefs.codegen.cpp.extra_compile_args = []
+        brian2.prefs._backup()
         brian2.set_device('genn')
 
 class GeNNConfigurationCPU(Configuration):
     name = 'GeNN_CPU'
     def before_run(self):
-        #brian2.prefs.reset_to_defaults()
-        brian2.prefs.devices.genn.unix_compiler_flags=''
-        brian2.prefs.devices.windows_compiler_flags=''
+        brian2.prefs.codegen.cpp.extra_compile_args = []
+        brian2.prefs._backup()
         brian2.set_device('genn', use_GPU=False)
 
 class GeNNConfigurationOptimized(Configuration):
-    name = 'GeNN'
+    name = 'GeNN_optimized'
     def before_run(self):
         brian2.prefs.reset_to_defaults()
+        brian2.prefs._backup()
         brian2.set_device('genn')
-

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -11,6 +11,7 @@ import numpy
 import numbers
 import time
 
+from brian2.codegen.cpp_prefs import get_compiler_and_args
 from brian2.spatialneuron.spatialneuron import SpatialNeuron, SpatialStateUpdater
 from brian2.units import second
 from brian2.codegen.generators.cpp_generator import c_data_type
@@ -1051,6 +1052,7 @@ class GeNNDevice(CPPStandaloneDevice):
         writer.write('engine.*', engine_tmp)
 
     def generate_makefile(self, directory, use_GPU):
+        _, compiler_flags = get_compiler_and_args()
         if os.sys.platform == 'win32':
             Makefile_tmp = GeNNCodeObject.templater.WINmakefile(None, None,
                                                                 neuron_models=self.neuron_models,
@@ -1059,7 +1061,8 @@ class GeNNDevice(CPPStandaloneDevice):
                                                                     directory),
                                                                 source_files=self.source_files,
                                                                 prefs=prefs,
-                                                                use_GPU=use_GPU
+                                                                use_GPU=use_GPU,
+                                                                compiler_flags=' '.join(compiler_flags)
                                                                 )
             open(os.path.join(directory, 'WINmakefile'), 'w').write(
                 Makefile_tmp)
@@ -1071,7 +1074,8 @@ class GeNNDevice(CPPStandaloneDevice):
                                                                     directory),
                                                                 source_files=self.source_files,
                                                                 prefs=prefs,
-                                                                use_GPU=use_GPU
+                                                                use_GPU=use_GPU,
+                                                                compiler_flags=' '.join(compiler_flags)
                                                                 )
             open(os.path.join(directory, 'GNUmakefile'), 'w').write(
                 Makefile_tmp)

--- a/brian2genn/preferences.py
+++ b/brian2genn/preferences.py
@@ -14,14 +14,8 @@ prefs.register_preferences(
         This preference determines which connectivity scheme is to be employed within GeNN. The valid alternatives are 'DENSE' and 'SPARSE'. For 'DENSE' the GeNN dense matrix methods are used for all connectivity matrices. When 'SPARSE' is chosen, the GeNN sparse matrix representations are used.''',
         default='SPARSE'
     ),
-    unix_compiler_flags= BrianPreference(
-        docs='''
-        This preference allows users to set their own compiler flags for the eventual compilation of GeNN generated code. The flags will be applied both for the nvcc compilation and C++ compiler compilation (e.g. gcc, clang). This preference is for unix-based operating systems. ''',
-        default='-O3 -ffast-math'
-    ),
-    windows_compiler_flags= BrianPreference(
-        docs='''
-                This preference allows users to set their own compiler flags for the eventual compilation of GeNN generated code. The flags will be applied both for the nvcc compilation and C++ compiler compilation (e.g. MCVC cl). This preference is for the windows operating system. ''',
-        default='/O2'
+    extra_compile_args_nvcc=BrianPreference(
+        docs='''Extra compile arguments (a list of strings) to pass to the nvcc compiler.''',
+        default=['-O3']
     )
 )

--- a/brian2genn/templates/GNUmakefile
+++ b/brian2genn/templates/GNUmakefile
@@ -6,7 +6,6 @@ CPU_ONLY	    = 1
 SOURCES         := main.cpp {% for source in source_files %} {{source}} {% endfor %} brianlib/randomkit/randomkit.c
 
 INCLUDE_FLAGS   := -I. -Ibrianlib/randomkit -Lbrianlib/randomkit
-OPTIMIZATIONFLAGS := {{prefs['devices.genn.unix_compiler_flags']}}
+OPTIMIZATIONFLAGS := {{compiler_flags}}
 
 include $(GENN_PATH)/userproject/include/makefile_common_gnu.mk
-

--- a/brian2genn/templates/GNUmakefile
+++ b/brian2genn/templates/GNUmakefile
@@ -7,5 +7,6 @@ SOURCES         := main.cpp {% for source in source_files %} {{source}} {% endfo
 
 INCLUDE_FLAGS   := -I. -Ibrianlib/randomkit -Lbrianlib/randomkit
 OPTIMIZATIONFLAGS := {{compiler_flags}}
+NVCC_OPTIMIZATIONFLAGS := {{nvcc_compiler_flags}}
 
 include $(GENN_PATH)/userproject/include/makefile_common_gnu.mk

--- a/brian2genn/templates/WINmakefile
+++ b/brian2genn/templates/WINmakefile
@@ -6,7 +6,7 @@ CPU_ONLY	= 1
 SOURCES		= main.cpp {% for source in source_files %} {{source}} {% endfor %} brianlib/randomkit/randomkit.c
 
 EXTRA_INCLUDE	= /I %CD% /I brianlib/randomkit
-OPTIMIZATIONFLAGS = {{prefs.devices.genn.windows_compiler_flags}}
+OPTIMIZATIONFLAGS = {{compiler_flags}}
 
 
 !include $(GENN_PATH)\userproject\include\makefile_common_win.mk

--- a/brian2genn/templates/WINmakefile
+++ b/brian2genn/templates/WINmakefile
@@ -7,6 +7,6 @@ SOURCES		= main.cpp {% for source in source_files %} {{source}} {% endfor %} bri
 
 EXTRA_INCLUDE	= /I %CD% /I brianlib/randomkit
 OPTIMIZATIONFLAGS = {{compiler_flags}}
-
+NVCC_OPTIMIZATIONFLAGS = {{nvcc_compiler_flags}}
 
 !include $(GENN_PATH)\userproject\include\makefile_common_win.mk

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -74,7 +74,12 @@ double *{{synapse_model.name}}_postsyn_ini= NULL;
 void modelDefinition(NNmodel &model)
 {
   initGeNN();
-  GENN_PREFERENCES::autoRefractory= 0;
+  GENN_PREFERENCES::autoRefractory = 0;
+  // Compiler optimization flags
+  GENN_PREFERENCES::userCxxFlagsWIN = "{{compile_args_msvc}}";
+  GENN_PREFERENCES::userCxxFlagsGNU = "{{compile_args_gcc}}";
+  GENN_PREFERENCES::userNvccFlags = "{{compile_args_nvcc}}";
+
   {{ dtDef }}
   // Define the relevant neuron models
   neuronModel n;

--- a/docs_sphinx/introduction/preferences.rst
+++ b/docs_sphinx/introduction/preferences.rst
@@ -18,9 +18,18 @@ sparse matrix methods ('SPARSE'). You can set the preference like this::
 
 Compiler preferences
 --------------------
-Brian2GeNN will use the compiler preferences specified for Brian2 (both for the
-C++ compiler call, as well as for NVIDIA's nvcc compiler). This means you should
-set the ``codegen.cpp.extra_compile_args`` preference, or set
+Brian2GeNN will use the compiler preferences specified for Brian2 for the
+C++ compiler call. This means you should set the
+`codegen.cpp.extra_compile_args`` preference, or set
 ``codegen.cpp.extra_compile_args_gcc`` and
 ``codegen.cpp.extra_compile_args_msvc`` to set preferences specifically for
 compilation under Linux/OS-X and Windows, respectively.
+
+Brian2GeNN also offers a preference to specify additional compiler flags for the
+CUDA compilation with the nvcc compiler: `devices.genn.extra_compile_args_nvcc`.
+
+Note that all of the above preferences expect a *Python list* of individual
+compiler arguments, i.e. to for example add an argument for the nvcc compiler,
+use::
+
+    prefs.devices.genn.extra_compile_args_nvcc += ['--verbose']

--- a/docs_sphinx/introduction/preferences.rst
+++ b/docs_sphinx/introduction/preferences.rst
@@ -3,10 +3,24 @@ Brian2GeNN specific preferences
 
 Connectivity
 ------------
-The preference ``prefs.devices.genn.connectivity`` determines what
+The preference ``devices.genn.connectivity`` determines what
 connectivity scheme is used within GeNN to represent the connections
 between neurons. GeNN supports the use of full connectivity matrices
 ('DENSE') or a representation where connections are represented with
-sparse matrix methods ('SPARSE').
+sparse matrix methods ('SPARSE'). You can set the preference like this::
+
+    from brian2 import *
+    import brian2genn
+    set_device('genn')
+
+    prefs.devices.genn.connectivity = 'DENSE'
 
 
+Compiler preferences
+--------------------
+Brian2GeNN will use the compiler preferences specified for Brian2 (both for the
+C++ compiler call, as well as for NVIDIA's nvcc compiler). This means you should
+set the ``codegen.cpp.extra_compile_args`` preference, or set
+``codegen.cpp.extra_compile_args_gcc`` and
+``codegen.cpp.extra_compile_args_msvc`` to set preferences specifically for
+compilation under Linux/OS-X and Windows, respectively.

--- a/docs_sphinx/introduction/preferences.rst
+++ b/docs_sphinx/introduction/preferences.rst
@@ -20,7 +20,7 @@ Compiler preferences
 --------------------
 Brian2GeNN will use the compiler preferences specified for Brian2 for the
 C++ compiler call. This means you should set the
-`codegen.cpp.extra_compile_args`` preference, or set
+``codegen.cpp.extra_compile_args`` preference, or set
 ``codegen.cpp.extra_compile_args_gcc`` and
 ``codegen.cpp.extra_compile_args_msvc`` to set preferences specifically for
 compilation under Linux/OS-X and Windows, respectively.


### PR DESCRIPTION
Not sure if you agree, but I think it might be simpler if Brian2GeNN just uses Brian's compiler optimization flags instead of GeNN-specific ones. Or do you think users will often set optimization flags differently for the two?