### PR TITLE
[MRG] Fix issues around threshold/resets and subexpressions and support functions

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -913,6 +913,11 @@ class GeNNDevice(CPPStandaloneDevice):
             combined_variables = {}
             combined_variable_indices = defaultdict(lambda: '_idx')
             combined_override_conditional_write = set()
+            thresholder_codeobj = getattr(objects.get(obj.name + '_thresholder', None), 'codeobj', None)
+            if thresholder_codeobj is not None:
+                neuron_model.thresh_cond_lines = '_cond'
+            else:
+                neuron_model.thresh_cond_lines = '0'
             for suffix, code_slot in [('_stateupdater', 'stateupdate'),
                                       ('_thresholder', 'stateupdate'),
                                       ('_resetter', 'reset')]:
@@ -936,10 +941,6 @@ class GeNNDevice(CPPStandaloneDevice):
                         combined_override_conditional_write.update(codeobj.override_conditional_write)
                     objects[full_name].codeobj = None
 
-            if objects.get(obj.name + '_thresholder', None) is not None:
-                neuron_model.thresh_cond_lines = '_cond'
-            else:
-                neuron_model.thresh_cond_lines = '0'
             if objects.get(obj.name + '_resetter', None) is not None:
                 if obj._refractory is not False:
                     combined_abstract_code['reset'] += ['lastspike = t',

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -151,15 +151,12 @@ def extract_source_variables(variables, varname, smvariables):
                                                        smvariables)
     return smvariables
 
-
-# Dummy classes used for delaying the CodeObject creation of stateupdater and
-# thresholder (which will be merged into a single code object):
-class DummyObject(object):
-    def __init__(self, codeobj):
-        self.codeobj = codeobj
-
-
-class DummyCodeObject(object):
+class DelayedCodeObject(object):
+    '''
+    Dummy class used for delaying the CodeObject creation of stateupdater,
+    thresholder, and resetter of a NeuronGroup (which will all be merged into a
+    single code object).
+    '''
     def __init__(self, owner, name, abstract_code, variables, variable_indices,
                  override_conditional_write):
         self.owner = owner
@@ -369,14 +366,14 @@ class GeNNDevice(CPPStandaloneDevice):
         '''
         if (template_name in ['stateupdate', 'threshold', 'reset'] and
                 isinstance(owner, NeuronGroup)):
-            # Delay the code generation process, we want to merge the two into
-            # one
-            codeobj = DummyCodeObject(owner=owner,
-                                      name=name,
-                                      abstract_code=abstract_code,
-                                      variables=variables,
-                                      variable_indices=variable_indices,
-                                      override_conditional_write=override_conditional_write)
+            # Delay the code generation process, we want to merge them into one
+            # code object later
+            codeobj = DelayedCodeObject(owner=owner,
+                                        name=name,
+                                        abstract_code=abstract_code,
+                                        variables=variables,
+                                        variable_indices=variable_indices,
+                                        override_conditional_write=override_conditional_write)
             self.simple_code_objects[name] = codeobj
         elif template_name in ['reset', 'synapses', 'stateupdate', 'threshold']:
             codeobj_class = GeNNCodeObject

--- a/brian2genn/templates/neuron_code.cpp
+++ b/brian2genn/templates/neuron_code.cpp
@@ -1,0 +1,12 @@
+{% macro stateupdate_code() %}
+{{(scalar_code['stateupdate'] + vector_code['stateupdate'])|autoindent}}
+{% endmacro %}
+
+{% macro reset_code() %}
+{{(scalar_code['reset'] + vector_code['reset'])|autoindent}}
+{% endmacro %}
+
+{% macro h_file() %}
+{{support_code_lines|autoindent}}
+{{hashdefine_lines|autoindent}}
+{% endmacro %}

--- a/brian2genn/templates/template_notes.txt
+++ b/brian2genn/templates/template_notes.txt
@@ -39,8 +39,14 @@ GNUmakefile
 WINmakefile
 engine.cc
 model.cc
-reset.cc
 runner.cc
-stateupdate.cc
 synapses.cc
+# The following templates are *not* used for NeuronGroup
+reset.cc
+stateupdate.cc
 threshold.cc
+# This template merges the code for stateupdate/threshold/reset in
+# NeuronGroups (in GeNN, they all share the same support Code)
+neuron_model.cc
+
+


### PR DESCRIPTION
This PR fixes #41 and the issue mentioned here: https://github.com/brian-team/brian2genn/issues/43#issuecomment-280394751.
Instead of creating individual `CodeObject`s for a `NeuronGroup`'s stateupdate, threshold, and reset, we first store their information into `DelayedCodeObject`s (which do nothing except to store the code, variables, etc.) and then later merge them all into one code object, after adding the abstract code for the threshold to the end of the stateupdate code.
This fixes:
1. Subexpressions can be used in threshold conditions (#41), since now multiple-line conditions will be calculated after the state update and stored into a boolean variable `_cond`; the actual threshold condition is then just `_cond`.
2. Since stateupdate, threshold, and reset now share a single `CodeObject`, Brian's code generation pipeline will only generate a single support code for them, avoiding duplicate definitions of functions (see https://github.com/brian-team/brian2genn/issues/43#issuecomment-280394751).

Note that for (1) to work, we currently need to use GeNN from the development branch -- this is why the first half of the test (which test `brian2genn` against GeNN's master branch) fail.

I added some quite long comments to the code to explain what is going on. @tnowotny : If you are happy with this, feel free to merge (this PR is a prerequisite to tackle #43).