### PR TITLE
[MRG] Bug fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ matrix:
 before_install:
 - if [ ${PYTHON:0:1} == "2" ]; then
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    travis_retry wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-$ARCHITECTURE.sh -O miniconda.sh;
+    travis_retry wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-$ARCHITECTURE.sh -O miniconda.sh;
     else
-    travis_retry wget http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-$ARCHITECTURE.sh -O miniconda.sh;
+    travis_retry wget http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-$ARCHITECTURE.sh -O miniconda.sh;
     fi;
     else
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -936,10 +936,9 @@ class GeNNDevice(CPPStandaloneDevice):
                         combined_override_conditional_write.update(codeobj.override_conditional_write)
                     objects[full_name].codeobj = None
 
-            if objects.get(obj.name + '_resetter', None) is not None:
-                if obj._refractory is not False:
-                    combined_abstract_code['reset'] += ['lastspike = t',
-                                                        'not_refractory = False']
+            if obj._refractory is not False:
+                combined_abstract_code['reset'] += ['lastspike = t',
+                                                    'not_refractory = False']
 
             combined_abstract_code['stateupdate'] = '\n'.join(combined_abstract_code['stateupdate'])
             combined_abstract_code['reset'] = '\n'.join(combined_abstract_code['reset'])

--- a/brian2genn/templates/main.cpp
+++ b/brian2genn/templates/main.cpp
@@ -111,6 +111,13 @@ int main(int argc, char *argv[])
   }
   {% endif %}
   {% endfor %}
+  {% for synapses in synapse_models %}
+  {% if '_seed' in synapses.variables %}
+  for (int i= 0; i < C{{synapses.name}}.connN; i++) {
+      _seed{{synapses.name}}[i]= (uint64_t) (rand()*MYRAND_MAX);
+  }
+  {% endif %}
+  {% endfor %}
 
   //-----------------------------------------------------------------
   


### PR DESCRIPTION
I noticed that two new Brian 2 tests were failing with Brian2GeNN for two reasons:
* Refractoriness information (`lastspike` and `not_refractory`) where only updated when the reset statement was not empty
* Seeds where only initialized for neurons, not for synapses (i.e. if a synaptic statement used a random number, this would be based on uninitialized memory, most likely giving many duplicate random numbers)

This PR fixes these two issues (let's wait whether the tests all run through, though).