### PR TITLE
[MRG] Add support for PoissonInput, constant over dt, and run_regularly

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -3,6 +3,7 @@ Module implementing the bulk of the brian2genn interface by defining the "genn" 
 '''
 
 import os
+import shutil
 import platform
 from subprocess import call, check_call, CalledProcessError
 import inspect
@@ -684,6 +685,12 @@ class GeNNDevice(CPPStandaloneDevice):
         self.generate_objects_source(arange_arrays, net, static_array_specs,
                                      synapses, writer)
         self.copy_source_files(writer, directory)
+        # Rename randomkit.c so that it gets compiled by an explicit rule in
+        # GeNN's makefile template, otherwise optimization flags will not be
+        # used.
+        randomkit_dir = os.path.join(directory, 'brianlib', 'randomkit')
+        shutil.move(os.path.join(randomkit_dir, 'randomkit.c'),
+                    os.path.join(randomkit_dir, 'randomkit.cc'))
         self.generate_code_objects(writer)
         self.generate_model_source(writer)
         self.generate_main_source(writer, main_lines)

--- a/brian2genn/genn_generator.py
+++ b/brian2genn/genn_generator.py
@@ -225,12 +225,13 @@ class GeNNCodeGenerator(CodeGenerator):
         dep_support_code = []
         if impl.dependencies is not None:
             for dep_name, dep in impl.dependencies.iteritems():
-                self.variables[dep_name] = dep
-                hd, ps, sc, uf = self._add_user_function(dep_name, dep)
-                dep_hash_defines.extend(hd)
-                dep_pointers.extend(ps)
-                dep_support_code.extend(sc)
-                user_functions.extend(uf)
+                if dep_name not in self.variables:  # do not add a dependency twice
+                    self.variables[dep_name] = dep
+                    hd, ps, sc, uf = self._add_user_function(dep_name, dep)
+                    dep_hash_defines.extend(hd)
+                    dep_pointers.extend(ps)
+                    dep_support_code.extend(sc)
+                    user_functions.extend(uf)
 
         return (dep_hash_defines + hash_defines,
                 dep_pointers + pointers,

--- a/brian2genn/templates/GNUmakefile
+++ b/brian2genn/templates/GNUmakefile
@@ -3,7 +3,7 @@ EXECUTABLE      := main
 {% if not use_GPU %}
 CPU_ONLY	    = 1
 {% endif %}
-SOURCES         := main.cpp {% for source in source_files %} {{source}} {% endfor %} brianlib/randomkit/randomkit.c
+SOURCES         := main.cpp {% for source in source_files %} {{source}} {% endfor %} brianlib/randomkit/randomkit.cc
 
 INCLUDE_FLAGS   := -I. -Ibrianlib/randomkit -Lbrianlib/randomkit
 OPTIMIZATIONFLAGS := {{compiler_flags}}

--- a/brian2genn/templates/WINmakefile
+++ b/brian2genn/templates/WINmakefile
@@ -3,7 +3,7 @@ EXECUTABLE	= main.exe
 {% if not use_GPU %}
 CPU_ONLY	= 1
 {% endif %}
-SOURCES		= main.cpp {% for source in source_files %} {{source}} {% endfor %} brianlib/randomkit/randomkit.c
+SOURCES		= main.cpp {% for source in source_files %} {{source}} {% endfor %} brianlib/randomkit/randomkit.cc
 
 INCLUDE_FLAGS	= /I %CD% /I brianlib/randomkit
 LINK_FLAGS = advapi32.lib

--- a/brian2genn/templates/neuron_code.cpp
+++ b/brian2genn/templates/neuron_code.cpp
@@ -2,11 +2,16 @@
 // Update "constant over dt" subexpressions (if any)
 {{(scalar_code['subexpression_update'] + vector_code['subexpression_update'])|autoindent}}
 {% if has_run_regularly %}
+
 // Run regular operations on a slower clock
 if (fabs(fmod(t, _run_regularly_dt)) < dt/2) {
     {{(scalar_code['run_regularly'] + vector_code['run_regularly'])|autoindent}}
 }
 {% endif %}
+
+// PoissonInputs targetting this group (if any)
+{{(scalar_code['poisson_input'] + vector_code['poisson_input'])|autoindent}}
+
 // Update state variables and the threshold condition
 {{(scalar_code['stateupdate'] + vector_code['stateupdate'])|autoindent}}
 {% endmacro %}

--- a/brian2genn/templates/neuron_code.cpp
+++ b/brian2genn/templates/neuron_code.cpp
@@ -1,10 +1,18 @@
 {% macro stateupdate_code() %}
+// Update "constant over dt" subexpressions (if any)
+{{(scalar_code['subexpression_update'] + vector_code['subexpression_update'])|autoindent}}
+// Update state variables and the threshold condition
 {{(scalar_code['stateupdate'] + vector_code['stateupdate'])|autoindent}}
 {% endmacro %}
 
 {% macro reset_code() %}
 {{(scalar_code['reset'] + vector_code['reset'])|autoindent}}
 {% endmacro %}
+
+{% macro subexpression_update_code() %}
+{{(scalar_code['subexpression_update'] + vector_code['subexpression_update'])|autoindent}}
+{% endmacro %}
+
 
 {% macro h_file() %}
 {{support_code_lines|autoindent}}

--- a/brian2genn/templates/neuron_code.cpp
+++ b/brian2genn/templates/neuron_code.cpp
@@ -1,3 +1,4 @@
+{# ALLOWS_SCALAR_WRITE #}
 {% macro stateupdate_code() %}
 // Update "constant over dt" subexpressions (if any)
 {{(scalar_code['subexpression_update'] + vector_code['subexpression_update'])|autoindent}}
@@ -6,7 +7,7 @@
 // Run regular operations on a slower clock
 int _timesteps = (int)(t/dt + 0.5);
 if (_timesteps % (int)_run_regularly_steps == 0) {  {# we need a type cast because GeNN parameters are double values #}
-    {{(scalar_code['run_regularly'] + vector_code['run_regularly'])|autoindent}}
+    {{vector_code['run_regularly']|autoindent}}  {# Note that the scalar code (if any) is in a separate code object #}
 }
 {% endif %}
 

--- a/brian2genn/templates/neuron_code.cpp
+++ b/brian2genn/templates/neuron_code.cpp
@@ -1,6 +1,12 @@
 {% macro stateupdate_code() %}
 // Update "constant over dt" subexpressions (if any)
 {{(scalar_code['subexpression_update'] + vector_code['subexpression_update'])|autoindent}}
+{% if has_run_regularly %}
+// Run regular operations on a slower clock
+if (fabs(fmod(t, _run_regularly_dt)) < dt/2) {
+    {{(scalar_code['run_regularly'] + vector_code['run_regularly'])|autoindent}}
+}
+{% endif %}
 // Update state variables and the threshold condition
 {{(scalar_code['stateupdate'] + vector_code['stateupdate'])|autoindent}}
 {% endmacro %}

--- a/brian2genn/templates/neuron_code.cpp
+++ b/brian2genn/templates/neuron_code.cpp
@@ -20,11 +20,6 @@ if (fabs(fmod(t, _run_regularly_dt)) < dt/2) {
 {{(scalar_code['reset'] + vector_code['reset'])|autoindent}}
 {% endmacro %}
 
-{% macro subexpression_update_code() %}
-{{(scalar_code['subexpression_update'] + vector_code['subexpression_update'])|autoindent}}
-{% endmacro %}
-
-
 {% macro h_file() %}
 {{support_code_lines|autoindent}}
 {{hashdefine_lines|autoindent}}

--- a/brian2genn/templates/neuron_code.cpp
+++ b/brian2genn/templates/neuron_code.cpp
@@ -1,10 +1,11 @@
 {% macro stateupdate_code() %}
 // Update "constant over dt" subexpressions (if any)
 {{(scalar_code['subexpression_update'] + vector_code['subexpression_update'])|autoindent}}
-{% if has_run_regularly %}
 
+{% if has_run_regularly %}
 // Run regular operations on a slower clock
-if (fabs(fmod(t, _run_regularly_dt)) < dt/2) {
+int _timesteps = (int)(t/dt + 0.5);
+if (_timesteps % (int)_run_regularly_steps == 0) {  {# we need a type cast because GeNN parameters are double values #}
     {{(scalar_code['run_regularly'] + vector_code['run_regularly'])|autoindent}}
 }
 {% endif %}

--- a/brian2genn/templates/run_regularly_scalar_code.cpp
+++ b/brian2genn/templates/run_regularly_scalar_code.cpp
@@ -1,0 +1,6 @@
+{# ALLOWS_SCALAR_WRITE #}
+{% extends 'common_group.cpp' %}
+{% block maincode %}
+int _vectorisation_idx = -1;
+{{scalar_code['None']|autoindent}}
+{% endblock %}


### PR DESCRIPTION
This PR implements a simple way to add support for `PoissonInput`, `(constant over dt)` subexpressions, and `run_regularly` operations. The basic approach is very simple: the respective update code is added to the neuron code, before the usual state update code. This means that there are of course several limits to the support (e.g. it only supports neurons, but not synapses, you cannot reschedule the code to a different slot, etc.), but it is certainly better than nothing. For `run_regularly`, it allows a dt that is a multiple of the standard dt -- it wouldn't make much sense to use a `run_regularly` operation with the same dt as the group. Unfortunately one major use case is not supported: `run_regularly` can not update a scalar/shared variable (such as a presented stimulus) -- I don't think we can pass any scalar code into GeNN, can we?

Hmm, actually thinking about it: we *could* probably include scalar code in the `neuronCode` wrapped in something like `if (id == 0)`? But is there a common idiom to do this both for CPU and GPU? Well, it's a separate issue, anyway.