### PR TITLE
[MRG] Simplify setup to use GeNN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ install:
     fi
   - travis_retry git clone $BRANCH_ARGUMENT https://github.com/genn-team/genn.git
   - export GENN_PATH=$(pwd)/genn
-  - export PATH=$PATH:$GENN_PATH/lib/bin
   - cd brian-team/brian2genn
 
 # command to run tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,8 +40,6 @@ install:
   - 'if "%DEPENDENCIES%" == "latest" set BRANCH_ARGUMENTS="-bdevelopment"'
   - 'git clone %BRANCH_ARGUMENTS% https://github.com/genn-team/genn.git'
   - 'set GENN_PATH=%CD%\genn'
-  - 'set PATH=%GENN_PATH%\lib\bin;%PATH%'
-  - 'setx PATH "%PATH%"'
   - 'cd brian2genn'
 
 build: false  # not a C# project

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -822,6 +822,10 @@ class GeNNDevice(CPPStandaloneDevice):
 
     def compile_source(self, debug, directory, use_GPU):
         with std_silent(debug):
+            if 'GENN_PATH' in os.environ:
+                genn_path = os.environ['GENN_PATH']
+            else:
+                raise RuntimeError('Set the GENN_PATH environment variable.')
             if os.sys.platform == 'win32':
                 vcvars_loc = prefs['codegen.cpp.msvc_vars_location']
                 if vcvars_loc == '':
@@ -847,14 +851,16 @@ class GeNNDevice(CPPStandaloneDevice):
 
                 vcvars_cmd = '"{vcvars_loc}" {arch_name}'.format(
                     vcvars_loc=vcvars_loc, arch_name=arch_name)
-
-                cmd = vcvars_cmd + " && genn-buildmodel.bat " + self.model_name + ".cpp"
+                buildmodel_cmd = os.path.join(genn_path, 'lib', 'bin',
+                                              'genn-buildmodel.bat')
+                cmd = vcvars_cmd + " && " + buildmodel_cmd + " " + self.model_name + ".cpp"
                 if not use_GPU:
                     cmd += ' -c'
                 cmd += ' && nmake /f WINmakefile clean && nmake /f WINmakefile'
                 check_call(cmd, cwd=directory)
             else:
-                args = ["genn-buildmodel.sh", self.model_name + '.cpp']
+                buildmodel_cmd = os.path.join(genn_path, 'lib', 'bin', 'genn-buildmodel.sh')
+                args = [buildmodel_cmd, self.model_name + '.cpp']
                 if not use_GPU:
                     args += ['-c']
                 check_call(args, cwd=directory)

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -822,10 +822,13 @@ class GeNNDevice(CPPStandaloneDevice):
 
     def compile_source(self, debug, directory, use_GPU):
         with std_silent(debug):
-            if 'GENN_PATH' in os.environ:
+            if prefs.devices.genn.path is not None:
+                genn_path = prefs.devices.genn.path
+            elif 'GENN_PATH' in os.environ:
                 genn_path = os.environ['GENN_PATH']
             else:
-                raise RuntimeError('Set the GENN_PATH environment variable.')
+                raise RuntimeError('Set the GENN_PATH environment variable or '
+                                   'the devices.genn.path preference.')
             if os.sys.platform == 'win32':
                 vcvars_loc = prefs['codegen.cpp.msvc_vars_location']
                 if vcvars_loc == '':
@@ -856,7 +859,7 @@ class GeNNDevice(CPPStandaloneDevice):
                 cmd = vcvars_cmd + " && " + buildmodel_cmd + " " + self.model_name + ".cpp"
                 if not use_GPU:
                     cmd += ' -c'
-                cmd += ' && nmake /f WINmakefile clean && nmake /f WINmakefile'
+                cmd += ' && nmake /f WINmakefile clean "GENN_PATH={genn_path}" && nmake /f WINmakefile "GENN_PATH={genn_path}"'.format(genn_path=genn_path)
                 check_call(cmd, cwd=directory)
             else:
                 buildmodel_cmd = os.path.join(genn_path, 'lib', 'bin', 'genn-buildmodel.sh')
@@ -864,8 +867,8 @@ class GeNNDevice(CPPStandaloneDevice):
                 if not use_GPU:
                     args += ['-c']
                 check_call(args, cwd=directory)
-                call(["make", "clean"], cwd=directory)
-                check_call(["make"], cwd=directory)
+                call(["make", "clean", "GENN_PATH=%s" % genn_path], cwd=directory)
+                check_call(["make", "GENN_PATH=%s" % genn_path], cwd=directory)
 
     def add_parameter(self, model, varname, variable):
         model.parameters.append(varname)

--- a/brian2genn/preferences.py
+++ b/brian2genn/preferences.py
@@ -1,6 +1,7 @@
 '''
 Preferences that relate to the brian2genn interface.
 '''
+import os
 
 from brian2.core.preferences import *
 
@@ -17,5 +18,10 @@ prefs.register_preferences(
     extra_compile_args_nvcc=BrianPreference(
         docs='''Extra compile arguments (a list of strings) to pass to the nvcc compiler.''',
         default=['-O3']
+    ),
+    path=BrianPreference(
+        docs='''The path to the GeNN installation (if not set, the GENN_PATH environment variable will be used instead)''',
+        default=None,
+        validator=lambda value: value is None or os.path.isdir(value)
     )
 )


### PR DESCRIPTION
To make installation easier for users that did not use GeNN before, this PR removes the need for the user to set `PATH` manually. Brian2GeNN will now use `$GENN_PATH/lib/bin` to call `genn-buildmodel.sh` directly. Also, since setting environmental variables might not be obvious to all users in the first place (and is different depending on the way you launch scripts), this PR adds an option to set a preference for the path instead.
