### PR TITLE
[MRG] Add a `timestep` implementation make it work with Brian 2.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then conda install --yes --quiet gcc; fi
   - cd ../..
   - if [ "$DEPENDENCIES" == "latest" ]; then
-       (cd brian-team/brian2genn/genn; git checkout development)
+       (cd brian-team/brian2genn/genn; git checkout master)
     fi
   - export GENN_PATH=$(pwd)/brian-team/brian2genn/genn
   - cd brian-team/brian2genn

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
   # Install GeNN
   - # Clone the GeNN submodule
   - 'git submodule update --init --recursive'
-  - 'if "%DEPENDENCIES%" == "latest" (cd genn && git checkout development && cd ..)'
+  - 'if "%DEPENDENCIES%" == "latest" (cd genn && git checkout master && cd ..)'
   - 'set GENN_PATH=%CD%\genn'
 
 build: false  # not a C# project

--- a/brian2genn/genn_generator.py
+++ b/brian2genn/genn_generator.py
@@ -89,15 +89,13 @@ class GeNNCodeGenerator(CodeGenerator):
 
     class_name = 'genn'
 
-    universal_support_code = ('#include <limits.h>\n' +
-                              _mod_support_code() +
-                              deindent('''
+    universal_support_code = _mod_support_code() + deindent('''
     #ifdef _MSC_VER
     #define _brian_pow(x, y) (pow((double)(x), (y)))
     #else
     #define _brian_pow(x, y) (pow((x), (y)))
     #endif
-    '''))
+    ''')
 
     def __init__(self, *args, **kwds):
         super(GeNNCodeGenerator, self).__init__(*args, **kwds)
@@ -289,7 +287,7 @@ class GeNNCodeGenerator(CodeGenerator):
             if func_namespace is not None:
                 self.variables.update(func_namespace)
 
-        support_code.insert(0, self.universal_support_code)
+        support_code.append(self.universal_support_code)
 
         keywords = {'pointers_lines': stripped_deindented_lines('\n'.join(pointers)),
                     'support_code_lines': stripped_deindented_lines('\n'.join(support_code)),
@@ -448,7 +446,7 @@ int _timestep(double t, double dt)
 __host__ __device__ int _timestep(double t, double dt)
 #endif
 {
-    const int _infinity_int = INT_MAX/2;
+    const int _infinity_int  = 1073741823;  // maximum 32bit integer divided by 2
     if (std::isinf (t))
     {
         if (t < 0)


### PR DESCRIPTION
Embarrassingly, I only now realized that the introduction of the `timestep` function (for deterministic refractory times: brian-team/brian2#962, brian-team/brian2#949) that we introduced with Brian 2.1.3 breaks `Brian2GeNN`... This PR should fix it by adding a CUDA-compatible implementation of `timestep`. The compatibility trick for `isinf` is copied from the Brian 2 implementation, it seems to be necessary on Windows with older versions of MSVC.