### PR TITLE
Bug in _timestep function related to different host and device ```isinf```

### DIFF
--- a/brian2genn/genn_generator.py
+++ b/brian2genn/genn_generator.py
@@ -447,7 +447,11 @@ __host__ __device__ int _timestep(double t, double dt)
 #endif
 {
     const int _infinity_int  = 1073741823;  // maximum 32bit integer divided by 2
+#ifdef __CUDA_ARCH__
+    if (isinf (t))
+#else
     if (std::isinf (t))
+#endif
     {
         if (t < 0)
             return -_infinity_int;


### PR DESCRIPTION
Small bug fix on the new _timestep function. It's annoying but one needs to use ```std::isinf``` on the host side but plainly ```isinf``` on the device side.