### PR TITLE
Fix `_last_run_time` recording

### DIFF
--- a/brian2genn/templates/engine.cpp
+++ b/brian2genn/templates/engine.cpp
@@ -201,14 +201,18 @@ void engine::run(double duration, //!< Duration of time to run the model for
       {% for rateMon in rate_monitor_models %}
       _run_{{rateMon.name}}_codeobject();
       {% endfor %}
+      {% if maximum_run_time is not none %}
       current= std::clock();
       elapsed_realtime= (double) (current - start)/CLOCKS_PER_SEC;
-      {% if maximum_run_time is not none %}
       if (elapsed_realtime > {{maximum_run_time}}) {
 	  break;
       }
       {% endif %}
   }  
+  {% if maximum_run_time is none %}
+  current= std::clock();
+  elapsed_realtime= (double) (current - start)/CLOCKS_PER_SEC;
+  {% endif %}
   Network::_last_run_time = elapsed_realtime;
   if (duration > 0.0)
   {


### PR DESCRIPTION
Previously `_last_run_time` was 0 if `maximum_run_time` was not specified. This is needed for the brian2 `run_speed_tests` to work correctly with brian2GeNN.