### PR TITLE
[MRG] Apply Brian2's latest changes related to division/mod and timestep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ install:
         BRIAN_CHANNEL="brian-team/label/dev";
     fi
   - travis_retry conda install --yes --quiet -c brian-team py-cpuinfo nose python=$PYTHON
-  - travis_retry conda install --yes --quiet -c conda-forge -c $BRIAN_CHANNEL brian2 sympy=1.1
+  - travis_retry conda install --yes --quiet -c $BRIAN_CHANNEL -c conda-forge  brian2 sympy=1.1
   # Install gcc via conda -- the version provided by Ubuntu in this container image is too old
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then conda install --yes --quiet gcc; fi
   - cd ../..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ install:
   - 'conda install --yes --quiet -c brian-team py-cpuinfo nose'
   - 'if "%DEPENDENCIES%" == "stable" (set BRIAN_CHANNEL="brian-team") else (set BRIAN_CHANNEL="brian-team/label/dev")'
   - 'conda install --yes --quiet tqdm'
-  - 'conda install --yes --quiet -c conda-forge -c %BRIAN_CHANNEL% brian2 sympy=1.1'
+  - 'conda install --yes --quiet -c %BRIAN_CHANNEL% -c conda-forge brian2 sympy=1.1'
   # Install GeNN
   - # Clone the GeNN submodule
   - 'git submodule update --init --recursive'

--- a/brian2genn/templates/main.cpp
+++ b/brian2genn/templates/main.cpp
@@ -68,19 +68,14 @@ int main(int argc, char *argv[])
   create_hidden_weightmatrix(brian::_dynamic_array_{{synapses.name}}__synaptic_pre, brian::_dynamic_array_{{synapses.name}}__synaptic_post, _hidden_weightmatrix{{synapses.name}},{{synapses.srcN}}, {{synapses.trgN}});
   {% else %} {# for sparse matrix representations #}
   allocate{{synapses.name}}(brian::_dynamic_array_{{synapses.name}}__synaptic_pre.size());
-   {% set _first_var = true %}
-   vector<vector<int32_t> > _{{synapses.name}}_bypre;
-   {% for var in synapses.variables %}
-   {% if synapses.variablescope[var] == 'brian' %}
-      {% if _first_var %}
-      {% set _mode = 'b2g::FULL_MONTY' %}
-      {% set _first_var = false %}
-      {% else %}
-      {% set _mode = 'b2g::COPY_ONLY' %}
-      {% endif %}
-      convert_dynamic_arrays_2_sparse_synapses(brian::_dynamic_array_{{synapses.name}}__synaptic_pre, brian::_dynamic_array_{{synapses.name}}__synaptic_post,
-                                               brian::_dynamic_array_{{synapses.name}}_{{var}}, C{{synapses.name}}, {{var}}{{synapses.name}},
-                                               {{synapses.srcN}}, {{synapses.trgN}}, _{{synapses.name}}_bypre, {{_mode}});
+  vector<vector<int32_t> > _{{synapses.name}}_bypre;
+  initialize_sparse_synapses(brian::_dynamic_array_{{synapses.name}}__synaptic_pre, brian::_dynamic_array_{{synapses.name}}__synaptic_post,
+                             C{{synapses.name}}, {{synapses.srcN}}, {{synapses.trgN}}, _{{synapses.name}}_bypre);
+  {% for var in synapses.variables %}
+  {% if synapses.variablescope[var] == 'brian' %}
+  convert_dynamic_arrays_2_sparse_synapses(brian::_dynamic_array_{{synapses.name}}__synaptic_pre, brian::_dynamic_array_{{synapses.name}}__synaptic_post,
+                                           brian::_dynamic_array_{{synapses.name}}_{{var}}, {{var}}{{synapses.name}},
+                                           {{synapses.srcN}}, {{synapses.trgN}}, _{{synapses.name}}_bypre);
   {% endif %}
   {% endfor %} {# all synapse variables #}
   {% endif %} {# dense/sparse #}


### PR DESCRIPTION
To be consistent with Brian2's semantics for division etc. (and to not fail the new tests), we have to apply the same changes for `_brian_mod`, `_brian_floordiv` and `_timestep`.