### PR TITLE
[MRG] Add code slots for the `device.insert_code` mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ matrix:
     - python: "2.7"
       env: PYTHON="2.7" CONDA_PY="27" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="yes"
       os: linux
-    - python: "3.5"
-      env: PYTHON="3.5" CONDA_PY="35" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="no"
-      os: linux
     - python: "3.6"
       env: PYTHON="3.6" CONDA_PY="36" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="no"
       os: linux
@@ -22,10 +19,6 @@ matrix:
       env: PYTHON="2.7" CONDA_PY="27" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="no"
       os: osx
       osx_image: xcode8.3
-    - python: "3.5"
-      env: PYTHON="3.5" CONDA_PY="35" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="no"
-      os: osx
-      osx_image: xcode8.3
     - python: "3.6"
       env: PYTHON="3.6" CONDA_PY="36" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="no"
       os: osx
@@ -33,18 +26,11 @@ matrix:
     - python: "2.7"
       env: PYTHON="2.7" CONDA_PY="27" ARCHITECTURE="x86_64" DEPENDENCIES="latest" ANACONDA_UPLOAD="no"
       os: linux
-    - python: "3.5"
-      env: PYTHON="3.5" CONDA_PY="35" ARCHITECTURE="x86_64" DEPENDENCIES="latest" ANACONDA_UPLOAD="no"
-      os: linux
     - python: "3.6"
       env: PYTHON="3.6" CONDA_PY="36" ARCHITECTURE="x86_64" DEPENDENCIES="latest" ANACONDA_UPLOAD="no"
       os: linux
     - python: "2.7"
       env: PYTHON="2.7" CONDA_PY="27" ARCHITECTURE="x86_64" DEPENDENCIES="latest" ANACONDA_UPLOAD="no"
-      os: osx
-      osx_image: xcode8.3
-    - python: "3.5"
-      env: PYTHON="3.5" CONDA_PY="35" ARCHITECTURE="x86_64" DEPENDENCIES="latest" ANACONDA_UPLOAD="no"
       os: osx
       osx_image: xcode8.3
     - python: "3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,8 @@ matrix:
 
 install:
   # Add the paths for anaconda
-  - 'set PATH=%PYTHON%;%PYTHON%\Library\bin;%PYTHON%\Scripts;%PATH%'
+  - 'set PATH=%PYTHON%;%PYTHON%\\Library\\bin;%PYTHON%\\Scripts;%PATH%'
+  - 'echo %PATH%'
   # Update conda itself
   - 'conda update --yes --quiet conda'
   # Activate the conda environment

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ install:
   # Update conda itself
   - 'conda update --yes --quiet conda'
   # Activate the conda environment
-  - 'conda activate'
+  - 'if "$PYTHON_VERSION" == "3.5" (activate) else (conda activate)'
   # Install Brian 2 and dependencies
   - 'conda install --yes --quiet -c conda-forge brian2 sympy=1.1 py-cpuinfo=3 nose'
   # For "latest" dependencies, install Brian 2 from github

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,13 +12,6 @@ environment:
       DEPENDENCIES: "stable"
       PYPI_UPLOAD_SOURCE: "no"
       ANACONDA_UPLOAD: "yes"
-    - PYTHON: "C:\\Miniconda35-x64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-      platform: x64
-      DEPENDENCIES: "stable"
-      ANACONDA_UPLOAD: "no"
-      PYPI_UPLOAD_SOURCE: "no"
     - PYTHON: "C:\\Miniconda-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
@@ -33,13 +26,6 @@ environment:
       DEPENDENCIES: "latest"
       ANACONDA_UPLOAD: "no"
       PYPI_UPLOAD_SOURCE: "no"
-    - PYTHON: "C:\\Miniconda35-x64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-      platform: x64
-      DEPENDENCIES: "latest"
-      ANACONDA_UPLOAD: "no"
-      PYPI_UPLOAD_SOURCE: "no"
     - PYTHON: "C:\\Miniconda-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
@@ -49,16 +35,16 @@ environment:
       PYPI_UPLOAD_SOURCE: "no"
 matrix:
   allow_failures:
-    - DEPENDENCIES: "stable"
+    - DEPENDENCIES: "latest"
 
 install:
   # Add the paths for anaconda
-  - 'set PATH=%PYTHON%;%PYTHON%\\Library\\bin;%PYTHON%\\Scripts;%PATH%'
+  - 'set PATH=%PYTHON%;%PYTHON%\Library\bin;%PYTHON%\Scripts;%PATH%'
   - 'echo %PATH%'
   # Update conda itself
   - 'conda update --yes --quiet conda'
   # Activate the conda environment
-  - 'if "$PYTHON_VERSION" == "3.5" (activate) else (conda activate)'
+  - 'conda activate'
   # Install Brian 2 and dependencies
   - 'conda install --yes --quiet -c conda-forge brian2 sympy=1.1 py-cpuinfo=3 nose'
   # For "latest" dependencies, install Brian 2 from github

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,6 +54,8 @@ matrix:
 install:
   # Add the paths for anaconda
   - 'set PATH=%PYTHON%;%PYTHON%\Library\bin;%PYTHON%\Scripts;%PATH%'
+  # Update conda itself
+  - 'conda update --yes --quiet conda'
   # Activate the conda environment
   - 'conda activate'
   # Install Brian 2 and dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,6 +54,8 @@ matrix:
 install:
   # Add the paths for anaconda
   - 'set PATH=%PYTHON%;%PYTHON%\Library\bin;%PYTHON%\Scripts;%PATH%'
+  # Activate the conda environment
+  - 'conda activate'
   # Install Brian 2 and dependencies
   - 'conda install --yes --quiet -c conda-forge brian2 sympy=1.1 py-cpuinfo=3 nose'
   # For "latest" dependencies, install Brian 2 from github

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -1445,12 +1445,13 @@ class GeNNDevice(CPPStandaloneDevice):
         writer.write('magicnetwork_model.cpp', model_tmp)
 
     def generate_main_source(self, writer, main_lines):
+        header_files = self.header_files + prefs['codegen.cpp.headers']
         runner_tmp = GeNNCodeObject.templater.main(None, None,
                                                    code_lines=self.code_lines,
                                                    neuron_models=self.neuron_models,
                                                    synapse_models=self.synapse_models,
                                                    main_lines=main_lines,
-                                                   header_files=self.header_files,
+                                                   header_files=header_files,
                                                    source_files=self.source_files,
                                                    )
         writer.write('main.*', runner_tmp)

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -347,6 +347,14 @@ class GeNNDevice(CPPStandaloneDevice):
         self.connectivityDict = dict()
         self.groupDict = dict()
 
+        # Overwrite the code slots defined in standard C++ standalone
+        self.code_lines = {'before_start': [],
+                           'after_start': [],
+                           'before_run': [],
+                           'after_run': [],
+                           'before_end': [],
+                           'after_end': []}
+
     def activate(self, build_on_run=True, **kwargs):
         new_prefs = {'codegen.generators.cpp.restrict_keyword': '__restrict',
                      'codegen.loop_invariant_optimisations': False,
@@ -1438,6 +1446,7 @@ class GeNNDevice(CPPStandaloneDevice):
 
     def generate_main_source(self, writer, main_lines):
         runner_tmp = GeNNCodeObject.templater.main(None, None,
+                                                   code_lines=self.code_lines,
                                                    neuron_models=self.neuron_models,
                                                    synapse_models=self.synapse_models,
                                                    main_lines=main_lines,

--- a/brian2genn/templates/main.cpp
+++ b/brian2genn/templates/main.cpp
@@ -37,12 +37,14 @@ int main(int argc, char *argv[])
   system(cmd.c_str());
   string name;
   name= OutDir+ "/"+ toString(argv[1]) + toString(".time");
-  FILE *timef= fopen(name.c_str(),"a");  
+  FILE *timef= fopen(name.c_str(),"a");
 
   timer.startTimer();
   fprintf(stderr, "# DT %f \n", DT);
   fprintf(stderr, "# totalTime %f \n", totalTime);
-  
+
+  {{'\n'.join(code_lines['before_start'])|autoindent}}
+
   //-----------------------------------------------------------------
   // build the neuronal circuitery
   engine eng;
@@ -52,6 +54,7 @@ int main(int argc, char *argv[])
   _init_arrays();
   _load_arrays();
   rk_randomseed(brian::_mersenne_twister_states[0]);
+  {{'\n'.join(code_lines['after_start'])|autoindent}}
   {
 	  using namespace brian;
 	  {{ main_lines | autoindent }}
@@ -130,7 +133,9 @@ int main(int argc, char *argv[])
 
   t= -DT;
   void *devPtr;
+  {{'\n'.join(code_lines['before_run'])|autoindent}}
   eng.run(totalTime, which); // run for the full duration
+  {{'\n'.join(code_lines['after_run'])|autoindent}}
   timer.stopTimer();
   cerr << t << " done ..." << endl;
   fprintf(timef,"%f \n", timer.getElapsedTime());
@@ -185,8 +190,10 @@ int main(int argc, char *argv[])
   {% endfor %}
   {% endfor %}
 
+  {{'\n'.join(code_lines['before_end'])|autoindent}}
   _write_arrays();
   _dealloc_arrays();
+  {{'\n'.join(code_lines['after_end'])|autoindent}}
   cerr << "everything finished." << endl;
   return 0;
 }

--- a/brian2genn/templates/main.cpp
+++ b/brian2genn/templates/main.cpp
@@ -11,7 +11,11 @@
 #include "magicnetwork_model_CODE/definitions.h"
 
 {% for header in header_files %}
+{% if header.startswith('"') or header.startswith('<') %}
+#include {{header}}
+{% else %}
 #include "{{header}}"
+{% endif %}
 {% endfor %}
 
 #include "engine.cpp"


### PR DESCRIPTION
This adds code slots that can be used with `device.insert_code`. This is basically the same as the change introduced for Brian2 standalone with PR brian-team/brian2#1006 but with additional `before_run` and `after_run` slots. Those are needed because in Brian2GeNN, the actual simulation run is not part of the "main lines".