### PR TITLE
I exposed the blocksize related preferences in GeNN to Brian2Genn users.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,20 @@ env:
 matrix:
   include:
 
-    - python: "2.7"
-      env: PYTHON="2.7" CONDA_PY="27" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="yes"
-      os: linux
-    - python: "3.6"
-      env: PYTHON="3.6" CONDA_PY="36" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="no"
-      os: linux
-    - python: "2.7"
-      env: PYTHON="2.7" CONDA_PY="27" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="no"
-      os: osx
-      osx_image: xcode8.3
-    - python: "3.6"
-      env: PYTHON="3.6" CONDA_PY="36" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="no"
-      os: osx
-      osx_image: xcode8.3
+#    - python: "2.7"
+#      env: PYTHON="2.7" CONDA_PY="27" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="yes"
+#      os: linux
+#    - python: "3.6"
+#      env: PYTHON="3.6" CONDA_PY="36" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="no"
+#      os: linux
+#    - python: "2.7"
+#      env: PYTHON="2.7" CONDA_PY="27" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="no"
+#      os: osx
+#      osx_image: xcode8.3
+#    - python: "3.6"
+#      env: PYTHON="3.6" CONDA_PY="36" ARCHITECTURE="x86_64" DEPENDENCIES="stable" ANACONDA_UPLOAD="no"
+#      os: osx
+#      osx_image: xcode8.3
     - python: "2.7"
       env: PYTHON="2.7" CONDA_PY="27" ARCHITECTURE="x86_64" DEPENDENCIES="latest" ANACONDA_UPLOAD="no"
       os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,20 +5,20 @@ environment:
     secure: 20R+TzZ9NRmt9ttc5/Bb8w==
 
   matrix:
-    - PYTHON: "C:\\Miniconda36-x64"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
-      platform: x64
-      DEPENDENCIES: "stable"
-      PYPI_UPLOAD_SOURCE: "no"
-      ANACONDA_UPLOAD: "yes"
-    - PYTHON: "C:\\Miniconda-x64"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-      platform: x64
-      DEPENDENCIES: "stable"
-      ANACONDA_UPLOAD: "no"
-      PYPI_UPLOAD_SOURCE: "yes"
+#    - PYTHON: "C:\\Miniconda36-x64"
+#      PYTHON_VERSION: "3.6"
+#      PYTHON_ARCH: "64"
+#      platform: x64
+#      DEPENDENCIES: "stable"
+#      PYPI_UPLOAD_SOURCE: "no"
+#      ANACONDA_UPLOAD: "yes"
+#    - PYTHON: "C:\\Miniconda-x64"
+#      PYTHON_VERSION: "2.7"
+#      PYTHON_ARCH: "64"
+#      platform: x64
+#      DEPENDENCIES: "stable"
+#      ANACONDA_UPLOAD: "no"
+#      PYPI_UPLOAD_SOURCE: "yes"
     - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -122,40 +122,6 @@ def get_compile_args():
 
     return compile_args_gcc, compile_args_msvc, compile_args_nvcc
 
-def get_genn_prefs():
-    '''
-    Get the GeNN preferences that are exposed in brian2genn user preferences. 
-    Uses the Brian2GeNN preferences `devices.genn.auto_choose_device`,
-    `devices.genn.default_device`, `devices.genn.optimise_blocksize`, 
-    `devices.genn.pre_synapse_reset_blocksize`, `devices.genn.neuron_blocksize`, 
-    `devices.genn.synapse_blocksize`, `devices.genn.learning_blocksize`,
-    `devices.genn.synapse_dynamics_blocksize`, `devices.genn.init_blocksize`,
-    `devices.genn.init_sparse_blocksize` 
-
-    Returns
-    -------
-    (genn_auto_choose_device, genn_default_device, optimise_blocksize, pre_synapse_reset_blocksize,
-    neuron_blocksize, synapse_blocksize, learning_blocksize, synapse_dynamics_blocksize, init_blocksize, 
-    init_sparse_blocksize) : (int, int, int, int, int, int, int, int, int, int)
-        "multuple" with the genn preference settings.
-    '''
-    if prefs.devices.genn.auto_choose_device:
-        genn_auto_choose_device= 1
-    else:
-        genn_auto_choose_device= 0
-    genn_default_device= prefs.devices.genn.default_device
-    if prefs.devices.genn.optimise_blocksize:
-        optimise_blocksize= 1
-    else:
-        optimise_blocksize= 0
-    pre_synapse_reset_blocksize= prefs.devices.genn.pre_synapse_reset_blocksize
-    neuron_blocksize= prefs.devices.genn.neuron_blocksize
-    synapse_blocksize= prefs.devices.genn.synapse_blocksize
-    learning_blocksize= prefs.devices.genn.learning_blocksize
-    synapse_dynamics_blocksize= prefs.devices.genn.synapse_dynamics_blocksize
-    init_blocksize= prefs.devices.genn.init_blocksize
-    init_sparse_blocksize= prefs.devices.genn.init_sparse_blocksize
-    return genn_auto_choose_device, genn_default_device, optimise_blocksize, pre_synapse_reset_blocksize, neuron_blocksize, synapse_blocksize, learning_blocksize, synapse_dynamics_blocksize, init_blocksize, init_sparse_blocksize
 
 def decorate(code, variables, shared_variables, parameters, do_final=True):
     '''
@@ -1477,7 +1443,6 @@ class GeNNDevice(CPPStandaloneDevice):
         synapses_classes_tmp = CPPStandaloneCodeObject.templater.synapses_classes(None, None)
         writer.write('synapses_classes.*', synapses_classes_tmp)
         compile_args_gcc, compile_args_msvc, compile_args_nvcc = get_compile_args()
-        genn_auto_choose_device, genn_default_device, genn_optimise_blocksize, genn_pre_synapse_reset_blocksize, genn_neuron_blocksize, genn_synapse_blocksize, genn_learning_blocksize, genn_synapse_dynamics_blocksize, genn_init_blocksize, genn_init_sparse_blocksize = get_genn_prefs()
         default_dtype = prefs.core.default_float_dtype
         if default_dtype == numpy.float32:
             precision = 'GENN_FLOAT'
@@ -1494,16 +1459,7 @@ class GeNNDevice(CPPStandaloneDevice):
                                                    compile_args_gcc=compile_args_gcc,
                                                    compile_args_msvc=compile_args_msvc,
                                                    compile_args_nvcc=compile_args_nvcc,
-                                                   genn_auto_choose_device=genn_auto_choose_device, 
-                                                   genn_default_device=genn_default_device,
-                                                   genn_optimise_blocksize=genn_optimise_blocksize,
-                                                   genn_pre_synapse_reset_blocksize=genn_pre_synapse_reset_blocksize,
-                                                   genn_neuron_blocksize=genn_neuron_blocksize,
-                                                   genn_synapse_blocksize=genn_synapse_blocksize,
-                                                   genn_learning_blocksize=genn_learning_blocksize,
-                                                   genn_synapse_dynamics_blocksize=genn_synapse_dynamics_blocksize,
-                                                   genn_init_blocksize=genn_init_blocksize,
-                                                   genn_init_sparse_blocksize=genn_init_sparse_blocksize,
+                                                   prefs=prefs,
                                                    precision=precision
                                                    )
         writer.write('magicnetwork_model.cpp', model_tmp)

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -125,20 +125,37 @@ def get_compile_args():
 def get_genn_prefs():
     '''
     Get the GeNN preferences that are exposed in brian2genn user preferences. 
-    Uses the Brian2GeNN preferences `devices.genn.auto_choose_device` and 
-    `devices.genn.default_device`
+    Uses the Brian2GeNN preferences `devices.genn.auto_choose_device`,
+    `devices.genn.default_device`, `devices.genn.optimise_blocksize`, 
+    `devices.genn.pre_synapse_reset_blocksize`, `devices.genn.neuron_blocksize`, 
+    `devices.genn.synapse_blocksize`, `devices.genn.learning_blocksize`,
+    `devices.genn.synapse_dynamics_blocksize`, `devices.genn.init_blocksize`,
+    `devices.genn.init_sparse_blocksize` 
 
     Returns
     -------
-    (genn_auto_choose_device, genn_default_device) : (int, int)
-        Tuple with the genn preference settings.
+    (genn_auto_choose_device, genn_default_device, optimise_blocksize, pre_synapse_reset_blocksize,
+    neuron_blocksize, synapse_blocksize, learning_blocksize, synapse_dynamics_blocksize, init_blocksize, 
+    init_sparse_blocksize) : (int, int, int, int, int, int, int, int, int, int)
+        "multuple" with the genn preference settings.
     '''
     if prefs.devices.genn.auto_choose_device:
         genn_auto_choose_device= 1
     else:
         genn_auto_choose_device= 0
     genn_default_device= prefs.devices.genn.default_device
-    return genn_auto_choose_device, genn_default_device
+    if prefs.devices.genn.optimise_blocksize:
+        optimise_blocksize= 1
+    else:
+        optimise_blocksize= 0
+    pre_synapse_reset_blocksize= prefs.devices.genn.pre_synapse_reset_blocksize
+    neuron_blocksize= prefs.devices.genn.neuron_blocksize
+    synapse_blocksize= prefs.devices.genn.synapse_blocksize
+    learning_blocksize= prefs.devices.genn.learning_blocksize
+    synapse_dynamics_blocksize= prefs.devices.genn.synapse_dynamics_blocksize
+    init_blocksize= prefs.devices.genn.init_blocksize
+    init_sparse_blocksize= prefs.devices.genn.init_sparse_blocksize
+    return genn_auto_choose_device, genn_default_device, optimise_blocksize, pre_synapse_reset_blocksize, neuron_blocksize, synapse_blocksize, learning_blocksize, synapse_dynamics_blocksize, init_blocksize, init_sparse_blocksize
 
 def decorate(code, variables, shared_variables, parameters, do_final=True):
     '''
@@ -1460,7 +1477,7 @@ class GeNNDevice(CPPStandaloneDevice):
         synapses_classes_tmp = CPPStandaloneCodeObject.templater.synapses_classes(None, None)
         writer.write('synapses_classes.*', synapses_classes_tmp)
         compile_args_gcc, compile_args_msvc, compile_args_nvcc = get_compile_args()
-        genn_auto_choose_device, genn_default_device = get_genn_prefs()
+        genn_auto_choose_device, genn_default_device, genn_optimise_blocksize, genn_pre_synapse_reset_blocksize, genn_neuron_blocksize, genn_synapse_blocksize, genn_learning_blocksize, genn_synapse_dynamics_blocksize, genn_init_blocksize, genn_init_sparse_blocksize = get_genn_prefs()
         default_dtype = prefs.core.default_float_dtype
         if default_dtype == numpy.float32:
             precision = 'GENN_FLOAT'
@@ -1479,6 +1496,14 @@ class GeNNDevice(CPPStandaloneDevice):
                                                    compile_args_nvcc=compile_args_nvcc,
                                                    genn_auto_choose_device=genn_auto_choose_device, 
                                                    genn_default_device=genn_default_device,
+                                                   genn_optimise_blocksize=genn_optimise_blocksize,
+                                                   genn_pre_synapse_reset_blocksize=genn_pre_synapse_reset_blocksize,
+                                                   genn_neuron_blocksize=genn_neuron_blocksize,
+                                                   genn_synapse_blocksize=genn_synapse_blocksize,
+                                                   genn_learning_blocksize=genn_learning_blocksize,
+                                                   genn_synapse_dynamics_blocksize=genn_synapse_dynamics_blocksize,
+                                                   genn_init_blocksize=genn_init_blocksize,
+                                                   genn_init_sparse_blocksize=genn_init_sparse_blocksize,
                                                    precision=precision
                                                    )
         writer.write('magicnetwork_model.cpp', model_tmp)

--- a/brian2genn/preferences.py
+++ b/brian2genn/preferences.py
@@ -32,51 +32,41 @@ prefs.register_preferences(
     auto_choose_device=BrianPreference(
         docs='''The GeNN preference autoChooseDevice that determines whether or not a GPU should be chosen automatically when multiple CUDA enabled devices are present.''',
         default=True,
-        validator=lambda value: value in [ True, False ]
     ),
     default_device=BrianPreference(
         docs='''The GeNN preference defaultDevice that determines CUDA enabled device should be used if it is not automatically chosen.''',
         default=0,
-        validator=lambda value: isinstance(value, int) 
     ),
     optimise_blocksize=BrianPreference(
         docs='''The GeNN preference optimiseBlockSize that determines whether GeNN should use its internal algorithms to optimise the different block sizes.''',
         default=True,
-        validator=lambda value: value in [ True, False ]
     ),
     pre_synapse_reset_blocksize=BrianPreference(
         docs='''The GeNN preference preSynapseResetBlockSize that determines the CUDA block size for the pre-synapse reset kernel if not set automatically by GeNN's block size optimisation.''',
-        default=0,
-        validator=lambda value: isinstance(value, int) 
+        default=32,
     ),
     neuron_blocksize=BrianPreference(
         docs='''The GeNN preference neuronBlockSize that determines the CUDA block size for the neuron kernel if not set automatically by GeNN's block size optimisation.''',
         default=32,
-        validator=lambda value: isinstance(value, int) 
     ),
     synapse_blocksize=BrianPreference(
         docs='''The GeNN preference synapseBlockSize that determines the CUDA block size for the neuron kernel if not set automatically by GeNN's block size optimisation.''',
         default=32,
-        validator=lambda value: isinstance(value, int) 
     ),
     learning_blocksize=BrianPreference(
         docs='''The GeNN preference learningBlockSize that determines the CUDA block size for the neuron kernel if not set automatically by GeNN's block size optimisation.''',
-        default=0,
-        validator=lambda value: isinstance(value, int) 
+        default=32,
     ),
     synapse_dynamics_blocksize=BrianPreference(
         docs='''The GeNN preference synapseDynamicsBlockSize that determines the CUDA block size for the neuron kernel if not set automatically by GeNN's block size optimisation.''',
-        default=0,
-        validator=lambda value: isinstance(value, int) 
+        default=32,
     ),
     init_blocksize=BrianPreference(
         docs='''The GeNN preference initBlockSize that determines the CUDA block size for the neuron kernel if not set automatically by GeNN's block size optimisation.''',
-        default=0,
-        validator=lambda value: isinstance(value, int) 
+        default=32,
     ),
     init_sparse_blocksize=BrianPreference(
         docs='''The GeNN preference initSparseBlockSize that determines the CUDA block size for the neuron kernel if not set automatically by GeNN's block size optimisation.''',
-        default=0,
-        validator=lambda value: isinstance(value, int) 
+        default=32,
     )
 )

--- a/brian2genn/preferences.py
+++ b/brian2genn/preferences.py
@@ -38,5 +38,45 @@ prefs.register_preferences(
         docs='''The GeNN preference defaultDevice that determines CUDA enabled device should be used if it is not automatically chosen.''',
         default=0,
         validator=lambda value: isinstance(value, int) 
+    ),
+    optimise_blocksize=BrianPreference(
+        docs='''The GeNN preference optimiseBlockSize that determines whether GeNN should use its internal algorithms to optimise the different block sizes.''',
+        default=True,
+        validator=lambda value: value in [ True, False ]
+    ),
+    pre_synapse_reset_blocksize=BrianPreference(
+        docs='''The GeNN preference preSynapseResetBlockSize that determines the CUDA block size for the pre-synapse reset kernel if not set automatically by GeNN's block size optimisation.''',
+        default=0,
+        validator=lambda value: isinstance(value, int) 
+    ),
+    neuron_blocksize=BrianPreference(
+        docs='''The GeNN preference neuronBlockSize that determines the CUDA block size for the neuron kernel if not set automatically by GeNN's block size optimisation.''',
+        default=32,
+        validator=lambda value: isinstance(value, int) 
+    ),
+    synapse_blocksize=BrianPreference(
+        docs='''The GeNN preference synapseBlockSize that determines the CUDA block size for the neuron kernel if not set automatically by GeNN's block size optimisation.''',
+        default=32,
+        validator=lambda value: isinstance(value, int) 
+    ),
+    learning_blocksize=BrianPreference(
+        docs='''The GeNN preference learningBlockSize that determines the CUDA block size for the neuron kernel if not set automatically by GeNN's block size optimisation.''',
+        default=0,
+        validator=lambda value: isinstance(value, int) 
+    ),
+    synapse_dynamics_blocksize=BrianPreference(
+        docs='''The GeNN preference synapseDynamicsBlockSize that determines the CUDA block size for the neuron kernel if not set automatically by GeNN's block size optimisation.''',
+        default=0,
+        validator=lambda value: isinstance(value, int) 
+    ),
+    init_blocksize=BrianPreference(
+        docs='''The GeNN preference initBlockSize that determines the CUDA block size for the neuron kernel if not set automatically by GeNN's block size optimisation.''',
+        default=0,
+        validator=lambda value: isinstance(value, int) 
+    ),
+    init_sparse_blocksize=BrianPreference(
+        docs='''The GeNN preference initSparseBlockSize that determines the CUDA block size for the neuron kernel if not set automatically by GeNN's block size optimisation.''',
+        default=0,
+        validator=lambda value: isinstance(value, int) 
     )
 )

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -83,7 +83,16 @@ void modelDefinition(NNmodel &model)
   // GENN_PREFERENCES set in brian2genn
   GENN_PREFERENCES::autoChooseDevice= {{genn_auto_choose_device}};
   GENN_PREFERENCES::defaultDevice= {{genn_default_device}};
-
+  GENN_PREFERENCES::optimiseBlockSize= {{genn_optimise_blocksize}};
+  GENN_PREFERENCES::preSynapseResetBlockSize= {{genn_pre_synapse_reset_blocksize}};
+  GENN_PREFERENCES::neuronBlockSize= {{genn_neuron_blocksize}};
+  GENN_PREFERENCES::synapseBlockSize= {{genn_synapse_blocksize}};
+  GENN_PREFERENCES::learningBlockSize= {{genn_learning_blocksize}};
+  GENN_PREFERENCES::synapseDynamicsBlockSize= {{genn_synapse_dynamics_blocksize}};
+  GENN_PREFERENCES::initBlockSize= {{genn_init_blocksize}};
+  GENN_PREFERENCES::initSparseBlockSize= {{genn_init_sparse_blocksize}};
+  
+    
   {{ dtDef }}
   // Define the relevant neuron models
   neuronModel n;

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -81,16 +81,16 @@ void modelDefinition(NNmodel &model)
   GENN_PREFERENCES::userNvccFlags = "{{compile_args_nvcc}}";
 
   // GENN_PREFERENCES set in brian2genn
-  GENN_PREFERENCES::autoChooseDevice= {{genn_auto_choose_device}};
-  GENN_PREFERENCES::defaultDevice= {{genn_default_device}};
-  GENN_PREFERENCES::optimiseBlockSize= {{genn_optimise_blocksize}};
-  GENN_PREFERENCES::preSynapseResetBlockSize= {{genn_pre_synapse_reset_blocksize}};
-  GENN_PREFERENCES::neuronBlockSize= {{genn_neuron_blocksize}};
-  GENN_PREFERENCES::synapseBlockSize= {{genn_synapse_blocksize}};
-  GENN_PREFERENCES::learningBlockSize= {{genn_learning_blocksize}};
-  GENN_PREFERENCES::synapseDynamicsBlockSize= {{genn_synapse_dynamics_blocksize}};
-  GENN_PREFERENCES::initBlockSize= {{genn_init_blocksize}};
-  GENN_PREFERENCES::initSparseBlockSize= {{genn_init_sparse_blocksize}};
+  GENN_PREFERENCES::autoChooseDevice = {{prefs['devices.genn.auto_choose_device']|int}};
+  GENN_PREFERENCES::defaultDevice = {{prefs['devices.genn.default_device']}};
+  GENN_PREFERENCES::optimiseBlockSize = {{prefs['devices.genn.optimise_blocksize']|int}};
+  GENN_PREFERENCES::preSynapseResetBlockSize = {{prefs['devices.genn.pre_synapse_reset_blocksize']}};
+  GENN_PREFERENCES::neuronBlockSize = {{prefs['devices.genn.neuron_blocksize']}};
+  GENN_PREFERENCES::synapseBlockSize = {{prefs['devices.genn.synapse_blocksize']}};
+  GENN_PREFERENCES::learningBlockSize = {{prefs['devices.genn.learning_blocksize']}};
+  GENN_PREFERENCES::synapseDynamicsBlockSize = {{prefs['devices.genn.synapse_dynamics_blocksize']}};
+  GENN_PREFERENCES::initBlockSize = {{prefs['devices.genn.init_blocksize']}};
+  GENN_PREFERENCES::initSparseBlockSize = {{prefs['devices.genn.init_sparse_blocksize']}};
   
     
   {{ dtDef }}


### PR DESCRIPTION
I did this to run a benchmark with fixed block sizes controlled from the brian2genn script, overriding the usual GeNN blocksize optimization. 
This exposes preferences for optimising blocksize or not and the individual blocksizes for all GeNN CUDA kernels. 
Users can now set ```devices.genn.optimise_blocksize= False``` and any blocksize, e.g. ```devices.genn.neuron_blocksize= 128``` to control block sizes individually.
I think it does not hurt to make this available to everybody in the next release.