### PR TITLE
Use new GeNN syntax in model

### DIFF
--- a/brian2genn/codeobject.py
+++ b/brian2genn/codeobject.py
@@ -21,7 +21,8 @@ class GeNNCodeObject(CodeObject):
     templater = Templater('brian2genn', '.cpp',
                           env_globals={'c_data_type': c_data_type,
                                        'openmp_pragma': openmp_pragma,
-                                       'constant_or_scalar': constant_or_scalar})
+                                       'constant_or_scalar': constant_or_scalar,
+                                       'zip': zip})
     generator_class = GeNNCodeGenerator
 
 class GeNNUserCodeObject(CPPStandaloneCodeObject):

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -31,16 +31,16 @@ public:
     });
     SET_VARS({
     {% for var, type in zip(neuron_model.variables, neuron_model.variabletypes) %}
-        {{"{{var}}", "{{type}}"}},
+        {"{{var}}", "{{type}}"},
     {% endfor %}
     });
     SET_EXTRA_GLOBAL_PARAMS({
     {% for var,type in zip(neuron_model.shared_variables, neuron_model.shared_variabletypes) %}
-        {{"{{var}}", "{{type}}"}},
+        {"{{var}}", "{{type}}"},
     {% endfor %}
     });
 };
-IMPLEMENT_MODEL({neuron_model.name}}NEURON);
+IMPLEMENT_MODEL({{neuron_model.name}}NEURON);
 {% endfor %}
 
 //
@@ -65,18 +65,18 @@ public:
     {% endfor %}
     });
 
-    SET_VARS({{
+    SET_VARS({
     {% for var, type in zip(synapse_model.variables, synapse_model.variabletypes) %}
-        {{"{{var}}", "{{type}}"}},
+        {"{{var}}", "{{type}}"},
     {% endfor %}
     {% if synapse_model.connectivity == 'DENSE' %}
-        {{"_hidden_weightmatrix", "char"}},
+        {"_hidden_weightmatrix", "char"},
     {% endif %}
-    }});
+    });
 
     SET_EXTRA_GLOBAL_PARAMS({
     {% for var, type in zip(synapse_model.shared_variables, synapse_model.shared_variabletypes) %}
-        {{"{{var}}", "{{type}}"}},
+        {"{{var}}", "{{type}}"},
     {% endfor %}
     });
 

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -26,17 +26,17 @@ public:
 
     SET_PARAM_NAMES({
     {% for par in neuron_model.parameters %}
-        "{{par}}",
+        "{{par}}"{% if not loop.last %},{% endif %}
     {% endfor %}
     });
     SET_VARS({
     {% for var, type in zip(neuron_model.variables, neuron_model.variabletypes) %}
-        {"{{var}}", "{{type}}"},
+        {"{{var}}", "{{type}}"}{% if not loop.last %},{% endif %}
     {% endfor %}
     });
     SET_EXTRA_GLOBAL_PARAMS({
     {% for var,type in zip(neuron_model.shared_variables, neuron_model.shared_variabletypes) %}
-        {"{{var}}", "{{type}}"},
+        {"{{var}}", "{{type}}"}{% if not loop.last %},{% endif %}
     {% endfor %}
     });
 };
@@ -61,22 +61,22 @@ public:
 
     SET_PARAM_NAMES({
     {% for par in synapse_model.parameters %}
-        "{{par}}",
+        "{{par}}"{% if not loop.last %},{% endif %}
     {% endfor %}
     });
 
     SET_VARS({
     {% for var, type in zip(synapse_model.variables, synapse_model.variabletypes) %}
-        {"{{var}}", "{{type}}"},
+        {"{{var}}", "{{type}}"}{% if not loop.last %},{% endif %}
     {% endfor %}
     {% if synapse_model.connectivity == 'DENSE' %}
-        {"_hidden_weightmatrix", "char"},
+        ,{"_hidden_weightmatrix", "char"}
     {% endif %}
     });
 
     SET_EXTRA_GLOBAL_PARAMS({
     {% for var, type in zip(synapse_model.shared_variables, synapse_model.shared_variabletypes) %}
-        {"{{var}}", "{{type}}"},
+        {"{{var}}", "{{type}}"}{% if not loop.last %},{% endif %}
     {% endfor %}
     });
 
@@ -102,7 +102,7 @@ IMPLEMENT_MODEL({{synapse_model.name}}POSTSYN);
 {% for neuron_model in neuron_models %}
 {{neuron_model.name}}NEURON::ParamValues {{neuron_model.name}}_p(
 {% for k in neuron_model.pvalue %}
-    {{k}},
+    {{k}}{% if not loop.last %},{% endif %}
 {% endfor %}
 );
 {% endfor %}
@@ -111,7 +111,7 @@ IMPLEMENT_MODEL({{synapse_model.name}}POSTSYN);
 {% for synapse_model in synapse_models %}
 {{synapse_model.name}}WEIGHTUPDATE::ParamValues {{synapse_model.name}}_p(
 {% for k in synapse_model.pvalue %}
-    {{k}},
+    {{k}}{% if not loop.last %},{% endif %}
 {% endfor %}
 );
 {% endfor %}
@@ -120,7 +120,7 @@ IMPLEMENT_MODEL({{synapse_model.name}}POSTSYN);
 {% for neuron_model in neuron_models %}
 {{neuron_model.name}}NEURON::VarValues {{neuron_model.name}}_ini(
     {% for k in neuron_model.variables %}
-    uninitialisedVar(),
+    uninitialisedVar(){% if not loop.last %},{% endif %}
     {% endfor %}
 );
 {% endfor %}
@@ -130,10 +130,10 @@ IMPLEMENT_MODEL({{synapse_model.name}}POSTSYN);
 {% for synapse_model in synapse_models %}
 {{synapse_model.name}}WEIGHTUPDATE::VarValues {{synapse_model.name}}_ini(
     {% for k in synapse_model.variables %}
-    uninitialisedVar(),
+    uninitialisedVar(){% if not loop.last %},{% endif %}
     {% endfor %}
     {% if synapse_model.connectivity == 'DENSE' %}
-    uninitialisedVar()
+    ,uninitialisedVar()
     {% endif %}
 );
 {% endfor %}
@@ -172,7 +172,7 @@ void modelDefinition(NNmodel &model)
     model.setTiming(true);
     {% endif %}
     {% for neuron_model in neuron_models %}
-    model.addNeuronPopulation<{{neuron_model.name}}NEURON>("{{neuron_model.name}}", {{neuron_model.N}}, , {{neuron_model.name}}_p, {{neuron_model.name}}_ini);
+    model.addNeuronPopulation<{{neuron_model.name}}NEURON>("{{neuron_model.name}}", {{neuron_model.N}}, {{neuron_model.name}}_p, {{neuron_model.name}}_ini);
     {% endfor %}
     {% for spikeGen_model in spikegenerator_models %}
     model.addNeuronPopulation<NeuronModels::SpikeSource>("{{spikeGen_model.name}}", {{spikeGen_model.N}}, {}, {});

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -186,7 +186,7 @@ void modelDefinition(NNmodel &model)
     delaySteps = {{synapse_model.delay}};
     {% endif %}
     model.addSynapsePopulation<{{synapse_model.name}}WEIGHTUPDATE, {{synapse_model.name}}POSTSYN>(
-        "{{synapse_model.name}}", {{synapse_model.connectivity}}, INDIVIDUALG, delaySteps,
+        "{{synapse_model.name}}", SynapseMatrixType::{{synapse_model.connectivity}}_INDIVIDUALG, delaySteps,
         "{{synapse_model.srcname}}", "{{synapse_model.trgname}}",
         {{synapse_model.name}}_p, {{synapse_model.name}}_ini,
         {}, {});

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -9,210 +9,191 @@
 */
 //--------------------------------------------------------------------------
 
-// 
-// define the neuron model types as integer variables
+//
+// define the neuron model classes
+
 {% for neuron_model in neuron_models %}
-unsigned int {{neuron_model.name}}NEURON;
+class {{neuron_model.name}}NEURON : public NeuronModels::Base
+{
+public:
+    DECLARE_MODEL({{neuron_model.name}}NEURON, {{neuron_model.pvalue.__len__()}}, {{neuron_model.variables.__len__()}});
+
+    SET_SIM_CODE("{% for line in neuron_model.code_lines %}{{line}}{% endfor %}");
+    SET_THRESHOLD_CONDITION_CODE("{% for line in neuron_model.thresh_cond_lines %}{{line}}{% endfor %}");
+    SET_RESET_CODE("{% for line in neuron_model.reset_code_lines %}{{line}}{% endfor %}");
+
+    SET_SUPPORT_CODE("{% for line in neuron_model.support_code_lines %}{{line}}{% endfor %}");
+
+    SET_PARAM_NAMES({
+    {% for par in neuron_model.parameters %}
+        "{{par}}",
+    {% endfor %}
+    });
+    SET_VARS({
+    {% for var, type in zip(neuron_model.variables, neuron_model.variabletypes) %}
+        {{"{{var}}", "{{type}}"}},
+    {% endfor %}
+    });
+    SET_EXTRA_GLOBAL_PARAMS({
+    {% for var,type in zip(neuron_model.shared_variables, neuron_model.shared_variabletypes) %}
+        {{"{{var}}", "{{type}}"}},
+    {% endfor %}
+    });
+};
+IMPLEMENT_MODEL({neuron_model.name}}NEURON);
 {% endfor %}
+
+//
+// define the synapse model classes
 {% for synapse_model in synapse_models %}
-unsigned int {{synapse_model.name}}WEIGHTUPDATE;
-unsigned int {{synapse_model.name}}POSTSYN;
+class {{synapse_model.name}}WEIGHTUPDATE : public WeightUpdateModels::Base
+{
+public:
+    DECLARE_MODEL({{synapse_model.name}}WEIGHTUPDATE, {{synapse_model.pvalue.__len__()}}, {{synapse_model.variables.__len__() + (1 if synapse_model.connectivity == 'DENSE' else 0)}});
+
+    SET_SIM_CODE("{% for line in synapse_model.main_code_lines['pre'] %}{{line}}{% endfor %}");
+    SET_LEARN_POST_CODE("{% for line in synapse_model.main_code_lines['post'] %}{{line}}{% endfor %}");
+    SET_SYNAPSE_DYNAMICS_CODE("{% for line in synapse_model.main_code_lines['dynamics'] %}{{line}}{% endfor %}");
+
+    SET_SIM_SUPPORT_CODE("{% for line in synapse_model.support_code_lines['pre'] %}{{line}}{% endfor %}");
+    SET_LEARN_POST_SUPPORT_CODE("{% for line in synapse_model.support_code_lines['post'] %}{{line}}{% endfor %}");
+    SET_SYNAPSE_DYNAMICS_SUPPORT_CODE("{% for line in synapse_model.support_code_lines['dynamics'] %}{{line}}{% endfor %}");
+
+    SET_PARAM_NAMES({
+    {% for par in synapse_model.parameters %}
+        "{{par}}",
+    {% endfor %}
+    });
+
+    SET_VARS({{
+    {% for var, type in zip(synapse_model.variables, synapse_model.variabletypes) %}
+        {{"{{var}}", "{{type}}"}},
+    {% endfor %}
+    {% if synapse_model.connectivity == 'DENSE' %}
+        {{"_hidden_weightmatrix", "char"}},
+    {% endif %}
+    }});
+
+    SET_EXTRA_GLOBAL_PARAMS({
+    {% for var, type in zip(synapse_model.shared_variables, synapse_model.shared_variabletypes) %}
+        {{"{{var}}", "{{type}}"}},
+    {% endfor %}
+    });
+
+    //SET_NEEDS_PRE_SPIKE_TIME(true);
+    //SET_NEEDS_POST_SPIKE_TIME(true);
+
+};
+
+IMPLEMENT_MODEL({{synapse_model.name}}WEIGHTUPDATE);
+
+class {{synapse_model.name}}POSTSYN : public PostsynapticModels::Base
+{
+public:
+    DECLARE_MODEL({{synapse_model.name}}POSTSYN, 0, 0);
+
+    SET_APPLY_INPUT_CODE("$(Isyn) += {% for line in synapse_model.postSyntoCurrent %}{{line}}{% endfor %};");
+};
+IMPLEMENT_MODEL({{synapse_model.name}}POSTSYN);
 {% endfor %}
 
 // parameter values
 // neurons
 {% for neuron_model in neuron_models %}
-{% if neuron_model.pvalue.__len__() == 0 %}
-double *{{neuron_model.name}}_p= NULL;
-{% else %}
-double {{neuron_model.name}}_p[{{neuron_model.pvalue.__len__()}}]= {
-  {% for k in neuron_model.pvalue %} {{k}},
-  {% endfor %}
-};
-{% endif %}
+{{neuron_model.name}}NEURON::ParamValues {{neuron_model.name}}_p(
+{% for k in neuron_model.pvalue %}
+    {{k}},
+{% endfor %}
+);
 {% endfor %}
 
 // synapses
 {% for synapse_model in synapse_models %}
-{% if synapse_model.pvalue.__len__() == 0 %}
-double *{{synapse_model.name}}_p= NULL;
-{% else %}
-double {{synapse_model.name}}_p[{{synapse_model.pvalue.__len__()}}]= {
-  {% for k in synapse_model.pvalue %} {{k}},
-  {% endfor %}
-};
-{% endif %}
-
-double *{{synapse_model.name}}_postsynp= NULL;
-
+{{synapse_model.name}}WEIGHTUPDATE::ParamValues {{synapse_model.name}}_p(
+{% for k in synapse_model.pvalue %}
+    {{k}},
+{% endfor %}
+);
 {% endfor %}
 
 // initial variables (neurons)
 {% for neuron_model in neuron_models %}
-double {{neuron_model.name}}_ini[{{neuron_model.variables.__len__()+1}}]= {
-  {% for k in neuron_model.variables %} 0.0,
-  {% endfor %}
-  0.0
-};
+{{neuron_model.name}}NEURON::VarValues {{neuron_model.name}}_ini(
+    {% for k in neuron_model.variables %}
+    uninitialisedVar(),
+    {% endfor %}
+);
 {% endfor %}
  
 // initial variables (synapses)
 // one additional initial variable for hidden_weightmatrix
 {% for synapse_model in synapse_models %}
-double {{synapse_model.name}}_ini[{{synapse_model.variables.__len__()+1}}]= {
-  {% for k in synapse_model.variables %} 0.0,
-  {% endfor %}
-  {% if synapse_model.connectivity == 'DENSE' %}
-  0.0
-  {% endif %}
-};
-
-double *{{synapse_model.name}}_postsyn_ini= NULL;
+{{synapse_model.name}}WEIGHTUPDATE::VarValues {{synapse_model.name}}_ini(
+    {% for k in synapse_model.variables %}
+    uninitialisedVar(),
+    {% endfor %}
+    {% if synapse_model.connectivity == 'DENSE' %}
+    uninitialisedVar()
+    {% endif %}
+);
 {% endfor %}
  
 
 void modelDefinition(NNmodel &model)
 {
-  initGeNN();
-  GENN_PREFERENCES::autoRefractory = 0;
-  // Compiler optimization flags
-  GENN_PREFERENCES::userCxxFlagsWIN = "{{compile_args_msvc}}";
-  GENN_PREFERENCES::userCxxFlagsGNU = "{{compile_args_gcc}}";
-  GENN_PREFERENCES::userNvccFlags = "{{compile_args_nvcc}}";
+    initGeNN();
+    GENN_PREFERENCES::autoRefractory = 0;
+    // Compiler optimization flags
+    GENN_PREFERENCES::userCxxFlagsWIN = "{{compile_args_msvc}}";
+    GENN_PREFERENCES::userCxxFlagsGNU = "{{compile_args_gcc}}";
+    GENN_PREFERENCES::userNvccFlags = "{{compile_args_nvcc}}";
 
-  // GENN_PREFERENCES set in brian2genn
-  GENN_PREFERENCES::autoChooseDevice = {{prefs['devices.genn.auto_choose_device']|int}};
-  GENN_PREFERENCES::defaultDevice = {{prefs['devices.genn.default_device']}};
-  GENN_PREFERENCES::optimiseBlockSize = {{prefs['devices.genn.optimise_blocksize']|int}};
-  GENN_PREFERENCES::preSynapseResetBlockSize = {{prefs['devices.genn.pre_synapse_reset_blocksize']}};
-  GENN_PREFERENCES::neuronBlockSize = {{prefs['devices.genn.neuron_blocksize']}};
-  GENN_PREFERENCES::synapseBlockSize = {{prefs['devices.genn.synapse_blocksize']}};
-  GENN_PREFERENCES::learningBlockSize = {{prefs['devices.genn.learning_blocksize']}};
-  GENN_PREFERENCES::synapseDynamicsBlockSize = {{prefs['devices.genn.synapse_dynamics_blocksize']}};
-  GENN_PREFERENCES::initBlockSize = {{prefs['devices.genn.init_blocksize']}};
-  GENN_PREFERENCES::initSparseBlockSize = {{prefs['devices.genn.init_sparse_blocksize']}};
-  
-    
-  {{ dtDef }}
-  // Define the relevant neuron models
-  neuronModel n;
+    // GENN_PREFERENCES set in brian2genn
+    GENN_PREFERENCES::autoChooseDevice = {{prefs['devices.genn.auto_choose_device']|int}};
+    GENN_PREFERENCES::defaultDevice = {{prefs['devices.genn.default_device']}};
+    GENN_PREFERENCES::optimiseBlockSize = {{prefs['devices.genn.optimise_blocksize']|int}};
+    GENN_PREFERENCES::preSynapseResetBlockSize = {{prefs['devices.genn.pre_synapse_reset_blocksize']}};
+    GENN_PREFERENCES::neuronBlockSize = {{prefs['devices.genn.neuron_blocksize']}};
+    GENN_PREFERENCES::synapseBlockSize = {{prefs['devices.genn.synapse_blocksize']}};
+    GENN_PREFERENCES::learningBlockSize = {{prefs['devices.genn.learning_blocksize']}};
+    GENN_PREFERENCES::synapseDynamicsBlockSize = {{prefs['devices.genn.synapse_dynamics_blocksize']}};
+    GENN_PREFERENCES::initBlockSize = {{prefs['devices.genn.init_blocksize']}};
+    GENN_PREFERENCES::initSparseBlockSize = {{prefs['devices.genn.init_sparse_blocksize']}};
 
-  {% for neuron_model in neuron_models %}
-  // step 1: add variables
-  n.varNames.clear();
-  n.varTypes.clear();
-  {% for var in neuron_model.variables %}
-  n.varNames.push_back("{{var}}");
-  {% endfor %}
-  {% for var in neuron_model.variabletypes %}
-  n.varTypes.push_back("{{var}}");
-  {% endfor %}
-  // step 2: add scalar (shared) variables
-  n.extraGlobalNeuronKernelParameters.clear();
-  n.extraGlobalNeuronKernelParameterTypes.clear();
-  {% for var in neuron_model.shared_variables %}
-  n.extraGlobalNeuronKernelParameters.push_back("{{var}}");
-  {% endfor %}
-  {% for vartype in neuron_model.shared_variabletypes %}
-  n.extraGlobalNeuronKernelParameterTypes.push_back("{{vartype}}");
-  {% endfor %}
-  // step 3: add parameters
-  n.pNames.clear(); 
-  {% for par in neuron_model.parameters %}
-  n.pNames.push_back("{{par}}");
-  {% endfor %}
-  // step 4: add simcode
-  n.simCode= "{% for line in neuron_model.code_lines %}{{line}}{% endfor %}";
-  // step 5: add thresholder code
-  n.thresholdConditionCode= "{% for line in neuron_model.thresh_cond_lines %}{{line}}{% endfor %}";
-  // step 6: add resetter code
-  n.resetCode= "{% for line in neuron_model.reset_code_lines %}{{line}}{% endfor %}";
-  // step 7: add support code
-  n.supportCode= "{% for line in neuron_model.support_code_lines %}{{line}}{% endfor %}";
-  nModels.push_back(n);
-  {{neuron_model.name}}NEURON= nModels.size()-1;
-  {% endfor %}
 
-  weightUpdateModel s;
-  postSynModel ps;  
-  {% for synapse_model in synapse_models %}
-  // synaptic model
-  s.varNames.clear();
-  s.varTypes.clear();
-  s.pNames.clear(); 
-  s.dpNames.clear();
-  // step 1: variables
-  {% for var in synapse_model.variables %}
-  s.varNames.push_back("{{var}}");
-  {% endfor %}
-  {% if synapse_model.connectivity == 'DENSE' %} 
-  s.varNames.push_back("_hidden_weightmatrix");
-  {% endif %}
-  {% for var in synapse_model.variabletypes %}
-  s.varTypes.push_back("{{var}}");
-  {% endfor %}
-  {% if synapse_model.connectivity == 'DENSE' %} 
-  s.varTypes.push_back("char");
-  {% endif %}
-  // step 2: scalar (shared) variables
-  s.extraGlobalSynapseKernelParameters.clear();
-  s.extraGlobalSynapseKernelParameterTypes.clear();
-  {% for var in synapse_model.shared_variables %}
-  s.extraGlobalSynapseKernelParameters.push_back("{{var}}");
-  {% endfor %}
-  {% for vartype in synapse_model.shared_variabletypes %}
-  s.extraGlobalSynapseKernelParameterTypes.push_back("{{vartype}}");
-  {% endfor %}
-  // step 3: add parameters
-  {% for par in synapse_model.parameters %}
-  s.pNames.push_back("{{par}}");
-  {% endfor %}
-  // step 4: add simcode
-  s.simCode= "{% for line in synapse_model.main_code_lines['pre'] %}{{line}}{% endfor %}";
-  s.simLearnPost= "{% for line in synapse_model.main_code_lines['post'] %}{{line}}{% endfor %}";
-  s.synapseDynamics= "{% for line in synapse_model.main_code_lines['dynamics'] %}{{line}}{% endfor %}";
-  s.simCode_supportCode= "{% for line in synapse_model.support_code_lines['pre'] %}{{line}}{% endfor %}";
-  s.simLearnPost_supportCode= "{% for line in synapse_model.support_code_lines['post'] %}{{line}}{% endfor %}";
-  s.synapseDynamics_supportCode= "{% for line in synapse_model.support_code_lines['dynamics'] %}{{line}}{% endfor %}";
-  weightUpdateModels.push_back(s);
-  {{synapse_model.name}}WEIGHTUPDATE= weightUpdateModels.size()-1;
-  // post-synaptic model
-  ps.varNames.clear();
-  ps.varTypes.clear();
-  ps.pNames.clear(); 
-  ps.dpNames.clear();
-  ps.postSyntoCurrent= "{% for line in synapse_model.postSyntoCurrent %}{{line}}{% endfor %}";
-  postSynModels.push_back(ps); 
-  {{synapse_model.name}}POSTSYN= postSynModels.size()-1;  
-  {% endfor %}
+    {{ dtDef }}
 
-  model.setName("magicnetwork_model");
-  model.setPrecision({{precision}});
-  {% if precision == 'GENN_FLOAT' %}
-  model.setTimePrecision(TimePrecision::DOUBLE);
-  {% endif %}
-  {% if prefs['devices.genn.kernel_timing'] %}
-  model.setTiming(true);
-  {% endif %}
-  {% for neuron_model in neuron_models %} 
-  model.addNeuronPopulation("{{neuron_model.name}}", {{neuron_model.N}}, {{neuron_model.name}}NEURON, {{neuron_model.name}}_p, {{neuron_model.name}}_ini);
-  {% endfor %}
-  {% for spikeGen_model in spikegenerator_models %} 
-  model.addNeuronPopulation("{{spikeGen_model.name}}", {{spikeGen_model.N}}, SPIKESOURCE, NULL, NULL);
-  {% endfor %}
-  unsigned int delaySteps;
-  {% for synapse_model in synapse_models %} 
-// TODO: Consider felxible use of DENSE and SPARSE (but beware of difficulty of judging which to use at compile time)
-  {% if synapse_model.delay == 0 %}
-  delaySteps = NO_DELAY;
-  {% else %}
-  delaySteps = {{synapse_model.delay}};
-  {% endif %}
-  model.addSynapsePopulation("{{synapse_model.name}}", {{synapse_model.name}}WEIGHTUPDATE, {{synapse_model.connectivity}}, INDIVIDUALG, delaySteps, {{synapse_model.name}}POSTSYN, "{{synapse_model.srcname}}", "{{synapse_model.trgname}}", {{synapse_model.name}}_ini, {{synapse_model.name}}_p, {{synapse_model.name}}_postsyn_ini, {{synapse_model.name}}_postsynp);
-  {% if prefs['devices.genn.synapse_span_type'] == 'PRESYNAPTIC' %}
-  model.setSpanTypeToPre("{{synapse_model.name}}");
-  {% endif %}
-  {% endfor %}
-  model.finalize();
+    model.setName("magicnetwork_model");
+    model.setPrecision({{precision}});
+    {% if precision == 'GENN_FLOAT' %}
+    model.setTimePrecision(TimePrecision::DOUBLE);
+    {% endif %}
+    {% if prefs['devices.genn.kernel_timing'] %}
+    model.setTiming(true);
+    {% endif %}
+    {% for neuron_model in neuron_models %}
+    model.addNeuronPopulation<{{neuron_model.name}}NEURON>("{{neuron_model.name}}", {{neuron_model.N}}, , {{neuron_model.name}}_p, {{neuron_model.name}}_ini);
+    {% endfor %}
+    {% for spikeGen_model in spikegenerator_models %}
+    model.addNeuronPopulation<NeuronModels::SpikeSource>("{{spikeGen_model.name}}", {{spikeGen_model.N}}, {}, {});
+    {% endfor %}
+    unsigned int delaySteps;
+    {% for synapse_model in synapse_models %}
+    // TODO: Consider flexible use of DENSE and SPARSE (but beware of difficulty of judging which to use at compile time)
+    {% if synapse_model.delay == 0 %}
+    delaySteps = NO_DELAY;
+    {% else %}
+    delaySteps = {{synapse_model.delay}};
+    {% endif %}
+    model.addSynapsePopulation<{{synapse_model.name}}WEIGHTUPDATE, {{synapse_model.name}}POSTSYN>(
+        "{{synapse_model.name}}", {{synapse_model.connectivity}}, INDIVIDUALG, delaySteps,
+        "{{synapse_model.srcname}}", "{{synapse_model.trgname}}",
+        {{synapse_model.name}}_p, {{synapse_model.name}}_ini,
+        {}, {});
+    {% if prefs['devices.genn.synapse_span_type'] == 'PRESYNAPTIC' %}
+    model.setSpanTypeToPre("{{synapse_model.name}}");
+    {% endif %}
+    {% endfor %}
+    model.finalize();
 }
 

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -2,7 +2,6 @@
 
 #include <stdint.h>
 #include "modelSpec.h"
-#include "global.h"
 
 //--------------------------------------------------------------------------
 /*! \brief This function defines the Brian2GeNN_model
@@ -100,42 +99,50 @@ IMPLEMENT_MODEL({{synapse_model.name}}POSTSYN);
 // parameter values
 // neurons
 {% for neuron_model in neuron_models %}
-{{neuron_model.name}}NEURON::ParamValues {{neuron_model.name}}_p(
+{{neuron_model.name}}NEURON::ParamValues {{neuron_model.name}}_p
+{% if neuron_model.pvalue.__len__() > 0 %}
+(
 {% for k in neuron_model.pvalue %}
     {{k}}{% if not loop.last %},{% endif %}
 {% endfor %}
-);
+){% endif %};
 {% endfor %}
 
 // synapses
 {% for synapse_model in synapse_models %}
-{{synapse_model.name}}WEIGHTUPDATE::ParamValues {{synapse_model.name}}_p(
+{{synapse_model.name}}WEIGHTUPDATE::ParamValues {{synapse_model.name}}_p
+{% if synapse_model.pvalue.__len__() > 0 %}
+(
 {% for k in synapse_model.pvalue %}
     {{k}}{% if not loop.last %},{% endif %}
 {% endfor %}
-);
+){% endif %};
 {% endfor %}
 
 // initial variables (neurons)
 {% for neuron_model in neuron_models %}
-{{neuron_model.name}}NEURON::VarValues {{neuron_model.name}}_ini(
+{{neuron_model.name}}NEURON::VarValues {{neuron_model.name}}_ini
+{% if neuron_model.variables.__len__() > 0 %}
+(
     {% for k in neuron_model.variables %}
     uninitialisedVar(){% if not loop.last %},{% endif %}
     {% endfor %}
-);
+){% endif %};
 {% endfor %}
  
 // initial variables (synapses)
 // one additional initial variable for hidden_weightmatrix
 {% for synapse_model in synapse_models %}
-{{synapse_model.name}}WEIGHTUPDATE::VarValues {{synapse_model.name}}_ini(
+{{synapse_model.name}}WEIGHTUPDATE::VarValues {{synapse_model.name}}_ini
+{% if synapse_model.variables.__len__() > 0 or synapse_model.connectivity == 'DENSE' %}
+(
     {% for k in synapse_model.variables %}
     uninitialisedVar(){% if not loop.last %},{% endif %}
     {% endfor %}
     {% if synapse_model.connectivity == 'DENSE' %}
     ,uninitialisedVar()
     {% endif %}
-);
+){% endif %};
 {% endfor %}
  
 

--- a/continuous-integration/azure-steps.yml
+++ b/continuous-integration/azure-steps.yml
@@ -2,7 +2,7 @@ steps:
   - task: CondaEnvironment@1
     inputs:
       environmentName: 'test_environment'
-      updateConda: true
+      updateConda: false
       packageSpecs: 'python=$(python.version) brian2 pip nose'
       installOptions: '-c conda-forge'
       createOptions: '-c conda-forge'

--- a/continuous-integration/azure-steps.yml
+++ b/continuous-integration/azure-steps.yml
@@ -2,10 +2,12 @@ steps:
   - task: CondaEnvironment@1
     inputs:
       environmentName: 'test_environment'
-      updateConda: True
+      updateConda: true
       packageSpecs: 'python=$(python.version) brian2 pip nose'
       installOptions: '-c conda-forge'
       createOptions: '-c conda-forge'
+      cleanEnvironment: true
+      createCustomEnvironment: true
 
   - script: python -m pip install --no-deps --ignore-installed --user .
     displayName: 'Install Brian2GeNN'


### PR DESCRIPTION
Brian2GeNN has been using the GeNN 2.X syntax for defining models. This has continued to be supported via wrappers in GeNN 3.X, but all newer GeNN features (e.g. #57) and we plan on deprecating this syntax entirely in the next major release. 

This PR updates the model.cpp template to use the new syntax.