### PR TITLE
[WIP] Fix SpikeGeneratorGroup and other incompatibilities

### DIFF
--- a/brian2genn/codeobject.py
+++ b/brian2genn/codeobject.py
@@ -1,7 +1,7 @@
 '''
 Brian2GeNN defines two different types of code objects, `GeNNCodeObject` and `GeNNUserCodeObject`.
 `GeNNCodeObject` is the class of code objects that produce code snippets for GeNN neuron or synapse models.
-`GeNNUserCodeObject` is the class of code objects that produce C++ code which is used as "user-side" code in GeNN. The class derives directly from Brian 2's `CPPStandaloneCodeObject`, using the `CPPCodeGenerator`.
+`GeNNUserCodeObject` is the class of code objects that produce C++ code which is used as "user-side" code in GeNN. The class derives directly from Brian 2's `CPPStandaloneCodeObject`, using teh `CPPCodeGenerator`.
 '''
 
 from brian2.devices.cpp_standalone.codeobject import CPPStandaloneCodeObject, openmp_pragma, constant_or_scalar

--- a/brian2genn/codeobject.py
+++ b/brian2genn/codeobject.py
@@ -1,7 +1,7 @@
 '''
 Brian2GeNN defines two different types of code objects, `GeNNCodeObject` and `GeNNUserCodeObject`.
 `GeNNCodeObject` is the class of code objects that produce code snippets for GeNN neuron or synapse models.
-`GeNNUserCodeObject` is the class of code objects that produce C++ code which is used as "user-side" code in GeNN. The class derives directly from Brian 2's `CPPStandaloneCodeObject`, using teh `CPPCodeGenerator`.
+`GeNNUserCodeObject` is the class of code objects that produce C++ code which is used as "user-side" code in GeNN. The class derives directly from Brian 2's `CPPStandaloneCodeObject`, using the `CPPCodeGenerator`.
 '''
 
 from brian2.devices.cpp_standalone.codeobject import CPPStandaloneCodeObject, openmp_pragma, constant_or_scalar
@@ -12,7 +12,7 @@ from brian2.codegen.templates import Templater
 from .genn_generator import *
 
 __all__ = ['GeNNCodeObject',
-           'GeNNUserCodeObject']    
+           'GeNNUserCodeObject']
 
 class GeNNCodeObject(CodeObject):
     '''

--- a/brian2genn/genn_generator.py
+++ b/brian2genn/genn_generator.py
@@ -135,7 +135,12 @@ class GeNNCodeGenerator(CodeGenerator):
     def translate_expression(self, expr):
         for varname, var in self.variables.iteritems():
             if isinstance(var, Function):
-                impl_name = var.implementations[self.codeobj_class].name
+                try:
+                    impl_name = var.implementations[self.codeobj_class].name
+                except KeyError:
+                    raise NotImplementedError('Function {} is not available '
+                                              'for use with '
+                                              'GeNN.'.format(var.name))
                 if impl_name is not None:
                     expr = word_substitute(expr, {varname: impl_name})
         return CPPNodeRenderer().render_expr(expr).strip()

--- a/brian2genn/templates/main.cpp
+++ b/brian2genn/templates/main.cpp
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
   // output general parameters to output file and start the simulation
   fprintf(stderr, "# We are running with fixed time step %f \n", DT);
 
-  t= -DT;
+  t= 0.;
   void *devPtr;
   {{'\n'.join(code_lines['before_run'])|autoindent}}
   eng.run(totalTime, which); // run for the full duration

--- a/brian2genn/templates/neuron_code.cpp
+++ b/brian2genn/templates/neuron_code.cpp
@@ -5,7 +5,8 @@
 
 {% if has_run_regularly %}
 // Run regular operations on a slower clock
-if (iT % (int)_run_regularly_steps == 0) {  {# we need a type cast because GeNN parameters are double values #}
+int _timesteps = (int)(t/dt + 0.5);
+if (_timesteps % (int)_run_regularly_steps == 0) {  {# we need a type cast because GeNN parameters are double values #}
     {{vector_code['run_regularly']|autoindent}}  {# Note that the scalar code (if any) is in a separate code object #}
 }
 {% endif %}

--- a/brian2genn/templates/spikegenerator.cpp
+++ b/brian2genn/templates/spikegenerator.cpp
@@ -1,4 +1,3 @@
-{# IS_OPENMP_COMPATIBLE #}
 {% extends 'common_group.cpp' %}
 
 {% block extra_headers %}
@@ -8,46 +7,35 @@
 extern unsigned int *{{_spikespace.replace('_ptr_array_','glbSpkCnt').replace('__spikespace','')}};
 extern unsigned int *{{_spikespace.replace('_ptr_array_','glbSpk').replace('__spikespace','')}};
 extern double t;
+extern unsigned long long iT;
 {% endblock %}
 
 {% block maincode %}
-    {# USES_VARIABLES {_spikespace, N, t, neuron_index, spike_time, period, _lastindex } #}
+    {# USES_VARIABLES { _spikespace, neuron_index, _timebins, _period_bins, _lastindex, N } #}
 
-    const double _the_period = {{period}};
-    const double padding_before = fmod(t, _the_period);
-    const double padding_after  = fmod(t+DT, _the_period);
-    const double epsilon        = 1e-3*DT;
+        const int32_t _the_period = {{_period_bins}};
+        int32_t _timebin          = iT;
 
-    // We need some precomputed values that will be used during looping
-    const bool not_end_period  = (fabs(padding_after) > epsilon) && (fabs(padding_after) < (_the_period - epsilon));
-    bool test;
+        if (_the_period > 0) {
+            _timebin %= _the_period;
+            // If there is a periodicity in the SpikeGenerator, we need to reset the
+            // lastindex when the period has passed
+            if ({{_lastindex}} > 0 && {{_timebins}}[{{_lastindex}} - 1] >= _timebin)
+                {{_lastindex}} = 0;
+        }
 
-    // TODO: We don't deal with more than one spike per neuron yet
-    long _cpp_numspikes = 0;
+        int32_t _cpp_numspikes = 0;
 
-    {{ openmp_pragma('single') }}
-    {
-        for(int _idx={{_lastindex}}; _idx < _numspike_time; _idx++)
+        for(int _idx={{_lastindex}}; _idx < _num_timebins; _idx++)
         {
-            if (not_end_period)
-                test = ({{spike_time}}[_idx] > padding_after) || (fabs({{spike_time}}[_idx] - padding_after) < epsilon);
-            else
-                // If we are in the last timestep before the end of the period, we remove the first part of the
-                // test, because padding will be 0
-                test = (fabs({{spike_time}}[_idx] - padding_after) < epsilon);
-            if (test)
+            if ({{_timebins}}[_idx] > _timebin)
                 break;
+
             {{_spikespace.replace('_ptr_array_','spike_').replace('__spikespace','')}}[_cpp_numspikes++] = {{neuron_index}}[_idx];
-        }       
+        }
 
         {{_spikespace.replace('_ptr_array_','spikeCount_').replace('__spikespace','')}} = _cpp_numspikes;
 
-        // If there is a periodicity in the SpikeGenerator, we need to reset the lastindex
-        // when all spikes have been played and at the end of the period
-        if (! not_end_period)
-            {{_lastindex}} = 0;
-        else
-            {{_lastindex}} += _cpp_numspikes;
-    }
+        {{_lastindex}} += _cpp_numspikes;
 
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(name='Brian2GeNN',
       },
       data_files=data_files,
       install_requires=[
-                        'brian2>=2.0',
+                        'brian2>=2.2.2.1',
                         'setuptools>=6.0',
                        ],
       setup_requires=[


### PR DESCRIPTION
I only now realized that changes in Brian 2 that were published with the latest release unfortunately completely break the functionality of `SpikeGeneratorGroup` in Brian2GeNN. The reason is that we greatly improved the handling of periods in `SpikeGeneratorGroup`, which entailed a different default value for the period: before, we use a very large value (as a proxy for "infinite"), now we use 0. Brian2GeNN still used the old algorithm which unfortunately does not handle a period of 0 well at all. I fix this in this PR, and also slightly changed the way the time is advanced during a run which became necessary with the changes because `SpikeGeneratorGroup` now makes use of the integer timestep `iT`.

Unfortunately I also discovered one more thing, apparently I did not run the full test suite on the *GPU* with the latest changes in Brian2GeNN. @tnowotny : the change to use `iT` for `run_regularly` operations (#83) only seems to work for the CPU-only mode, not on the GPU. `iT` is a global host variable but cannot be accessed on the device. I do not see an easy fix in Brian2GeNN (I think in GeNN we could change the signature of the `calcNeurons` function to include `iT` in addition to `t`), but maybe you do? If not, a quick&easy solution would be of course to revert the change merged with #83, it was only meant as an optimization after all.

As soon as we have dealt with this, we should make a 1.3.1 release.