### PR TITLE
Summed variables

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,9 @@
 # Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
+variables:
+  genn_stable: '3.3.0'
+
 jobs:
 
 - job: 'Linux'

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -145,12 +145,12 @@ def extract_source_variables(variables, varname, smvariables):
     '''
     identifiers = get_identifiers(variables[varname].expr)
     for vnm, var in variables.items():
-        if var in defaultclock.variables.values():
-            raise NotImplementedError('Recording an expression that depends on '
-                                      'the time t or the timestep dt is '
-                                      'currently not supported in Brian2GeNN')
         if vnm in identifiers:
-            if isinstance(var, ArrayVariable):
+            if var in defaultclock.variables.values():
+                raise NotImplementedError('Recording an expression that depends on '
+                                          'the time t or the timestep dt is '
+                                          'currently not supported in Brian2GeNN')
+            elif isinstance(var, ArrayVariable):
                 smvariables.append(vnm)
             elif isinstance(var, Subexpression):
                 smvariables = extract_source_variables(variables, vnm,

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -1339,7 +1339,10 @@ class GeNNDevice(CPPStandaloneDevice):
                                           "variables that target the post-synaptic neuron group of the Synapses the variable is defined in.")
                     synapse_model.postSyntoCurrent = '0; $(' + summed_variable_updater.target_var.name + ') += $(inSyn); $(inSyn)= 0'
                     # also add the inSyn updating code to the synapse dynamics code
-                    code= '\\n\ \n $(addToInSyn,$('+summed_variable_updater.abstract_code.replace('_synaptic_var = ','').replace('\n','').replace(' ','')+'));\\n'
+                    addVar= summed_variable_updater.abstract_code.replace('_synaptic_var = ','').replace('\n','').replace(' ','')
+                    for v in synapse_model.variables:
+                        addVar= addVar.replace(v,'$('+v+')')
+                    code= '\\n\\\n $(addToInSyn,'+addVar+');\\n'
                     synapse_model.main_code_lines['dynamics']+= code
                 else:
                     synapse_model.postSyntoCurrent = '0'

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -1327,7 +1327,7 @@ class GeNNDevice(CPPStandaloneDevice):
                                           "or a single summed variable per Synapses group.")
             if (len(synapse_model.summed_variables) > 1):
                  raise NotImplementedError("brian2genn only supports a "
-                                          "a single summed variable per Synapses group.")
+                                          "single summed variable per Synapses group.")
             if (hasattr(obj, '_genn_post_write_var')):
                 synapse_model.postSyntoCurrent = '0; $(' + obj._genn_post_write_var.replace(
                     '_post', '') + ') += $(inSyn); $(inSyn)= 0'

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -1325,6 +1325,9 @@ class GeNNDevice(CPPStandaloneDevice):
                 raise NotImplementedError("brian2genn only supports a "
                                           "either a single synaptic output variable "
                                           "or a single summed variable per Synapses group.")
+            if (len(synapse_model.summed_variables) > 0 and isinstance(obj.target,Subgroup)):
+                raise NotImplementedError("brian2genn does not support summed variables "
+                                          "when the target is a Subgroup.")
             if (len(synapse_model.summed_variables) > 1):
                  raise NotImplementedError("brian2genn only supports a "
                                           "single summed variable per Synapses group.")
@@ -1337,7 +1340,7 @@ class GeNNDevice(CPPStandaloneDevice):
                     if (obj.target != summed_variable_updater.target):
                         raise NotImplementedError("brian2genn only supports summed "
                                           "variables that target the post-synaptic neuron group of the Synapses the variable is defined in.")
-                    synapse_model.postSyntoCurrent = '0; $(' + summed_variable_updater.target_var.name + ') += $(inSyn); $(inSyn)= 0'
+                    synapse_model.postSyntoCurrent = '0; $(' + summed_variable_updater.target_var.name + ') = $(inSyn); $(inSyn)= 0'
                     # also add the inSyn updating code to the synapse dynamics code
                     addVar= summed_variable_updater.abstract_code.replace('_synaptic_var = ','').replace('\n','').replace(' ','')
                     for v in synapse_model.variables:

--- a/brian2genn/genn_generator.py
+++ b/brian2genn/genn_generator.py
@@ -192,7 +192,8 @@ class GeNNCodeGenerator(CodeGenerator):
                 post_write_var, statements = check_pre_code(self, statements,
                                                 vars_pre, vars_syn, vars_post,
                                                 conditional_write_vars)
-                self.owner._genn_post_write_var = post_write_var
+                if (post_write_var != None):
+                    self.owner._genn_post_write_var = post_write_var
         lines = []
         lines += self.translate_to_statements(statements)
         code = '\n'.join(lines)

--- a/brian2genn/insyn.py
+++ b/brian2genn/insyn.py
@@ -71,7 +71,7 @@ def check_pre_code(codegen, stmts, vars_pre, vars_syn, vars_post,
         raise NotImplementedError("GeNN only supports writing to a single postsynaptic variable.")
     if len(post_write)==0:
         logger.warn("Warning: You have defined (a) synaptic group(s) that has no direct postsynaptic effect.")
-        return None, []
+        return None, stmts
     
     post_write_var = list(post_write)[0]
         

--- a/brian2genn/insyn.py
+++ b/brian2genn/insyn.py
@@ -48,6 +48,9 @@ call this function and rewrite the appropriate statement.
 '''
 from brian2.utils.stringtools import get_identifiers
 from brian2.codegen.statements import Statement
+from brian2.utils.logger import get_logger
+
+logger = get_logger('brian2.devices.genn')
 
 def check_pre_code(codegen, stmts, vars_pre, vars_syn, vars_post,
                    conditional_write_vars):
@@ -64,10 +67,11 @@ def check_pre_code(codegen, stmts, vars_pre, vars_syn, vars_post,
     read, write, indices = codegen.array_read_write(stmts)
     
     post_write = set(write).intersection(set(vars_post))
-    if len(post_write)==0:
-        raise NotImplementedError("GeNN does not support Synapses with no postsynaptic effect.")
     if len(post_write)>1:
         raise NotImplementedError("GeNN only supports writing to a single postsynaptic variable.")
+    if len(post_write)==0:
+        logger.warn("Warning: You have defined (a) synaptic group(s) that has no direct postsynaptic effect.")
+        return None, []
     
     post_write_var = list(post_write)[0]
         

--- a/continuous-integration/azure-steps.yml
+++ b/continuous-integration/azure-steps.yml
@@ -1,3 +1,6 @@
+variables:
+  global_variable: value
+
 steps:
   - task: CondaEnvironment@1
     inputs:
@@ -16,9 +19,7 @@ steps:
       git clone --depth=1 https://github.com/genn-team/genn.git ../genn
       cd ../genn
       if [ $(use_genn_master) == 'false' ]; then
-        git fetch --tags
-        latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
-        git checkout $latestTag
+        git checkout $(genn_stable)
       fi
     displayName: 'Install GeNN'
 

--- a/continuous-integration/azure-steps.yml
+++ b/continuous-integration/azure-steps.yml
@@ -16,6 +16,7 @@ steps:
       git clone --depth=1 https://github.com/genn-team/genn.git ../genn
       cd ../genn
       if [ $(use_genn_master) == 'false' ]; then
+        git fetch --tags
         git checkout $(genn_stable)
       fi
     displayName: 'Install GeNN'

--- a/continuous-integration/azure-steps.yml
+++ b/continuous-integration/azure-steps.yml
@@ -1,6 +1,3 @@
-variables:
-  global_variable: value
-
 steps:
   - task: CondaEnvironment@1
     inputs:

--- a/examples/testSummedVars.py
+++ b/examples/testSummedVars.py
@@ -10,7 +10,7 @@ neurons = NeuronGroup(1, """dv/dt = (g-v)/(10*ms) : 1
 H = NeuronGroup(10, 'V:1', threshold='V > 0.5')
 
 S = Synapses(H, neurons,'''
-                dg_syn/dt = -g_syn/(100*ms) : 1 (clock-driven)
+                dg_syn/dt = -g_syn/(100*ms) : 1 (event-driven)
                 g_post = 2*g_syn : 1 (summed)''', on_pre='g_syn= g_syn+1')
 
 

--- a/examples/testSummedVars.py
+++ b/examples/testSummedVars.py
@@ -4,15 +4,19 @@ import brian2genn
 set_device('genn', directory='testSummedVars', use_GPU= False)
 #set_device('cpp_standalone')
 
-
 neurons = NeuronGroup(1, """dv/dt = (g-v)/(10*ms) : 1
-                            g : 1""", method='exact')
+                            g : 1""", method='exact', threshold= 'v > 0.1', reset= 'v= 0')
+neurons.g= 0.2
 H = NeuronGroup(10, 'V:1', threshold='V > 0.5')
 
-S = Synapses(H, neurons,'''
-                dg_syn/dt = -g_syn/(100*ms) : 1 (event-driven)
-                g_post = 2*g_syn : 1 (summed)''', on_pre='g_syn= g_syn+1')
-
-
+S = Synapses(neurons,H,'''
+               dg_syn/dt = -g_syn/(100*ms) : 1 (clock-driven)
+                V_post = g_syn : 1 (summed)''', on_pre='g_syn= g_syn+1')
 S.connect(True)
+mon= StateMonitor(S,variables=True,record= range(10))
+mon2= StateMonitor(neurons, variables=True, record= True)
+mon3= StateMonitor(H,variables=True, record= True)
 run(101*ms)
+
+plot(mon3.t,mon3.V.T)
+show()

--- a/examples/testSummedVars.py
+++ b/examples/testSummedVars.py
@@ -10,7 +10,7 @@ neurons.g= 0.2
 H = NeuronGroup(10, 'V:1', threshold='V > 0.5')
 
 S = Synapses(neurons,H,'''
-               dg_syn/dt = -g_syn/(100*ms) : 1 (clock-driven)
+               dg_syn/dt = -g_syn/(100*ms) : 1 (event-driven)
                 V_post = g_syn : 1 (summed)''', on_pre='g_syn= g_syn+1')
 S.connect(True)
 mon= StateMonitor(S,variables=True,record= range(10))

--- a/examples/testSummedVars.py
+++ b/examples/testSummedVars.py
@@ -11,7 +11,7 @@ H = NeuronGroup(10, 'V:1', threshold='V > 0.5')
 
 S = Synapses(H, neurons,'''
                 dg_syn/dt = -g_syn/(100*ms) : 1 (clock-driven)
-                g_post = g_syn : 1 (summed)''', on_pre='g_syn= g_syn+1')
+                g_post = 2*g_syn : 1 (summed)''', on_pre='g_syn= g_syn+1')
 
 
 S.connect(True)

--- a/examples/testSummedVars.py
+++ b/examples/testSummedVars.py
@@ -7,11 +7,11 @@ set_device('genn', directory='testSummedVars', use_GPU= False)
 
 neurons = NeuronGroup(1, """dv/dt = (g-v)/(10*ms) : 1
                             g : 1""", method='exact')
-H = NeuronGroup(10, 'V:1')
+H = NeuronGroup(10, 'V:1', threshold='V > 0.5')
 
 S = Synapses(H, neurons,'''
                 dg_syn/dt = -g_syn/(100*ms) : 1 (clock-driven)
-                g_post = g_syn : 1 (summed)''')
+                g_post = g_syn : 1 (summed)''', on_pre='g_syn= g_syn+1')
 
 
 S.connect(True)

--- a/examples/testSummedVars.py
+++ b/examples/testSummedVars.py
@@ -1,0 +1,18 @@
+from brian2 import *
+import brian2genn
+
+set_device('genn', directory='testSummedVars', use_GPU= False)
+#set_device('cpp_standalone')
+
+
+neurons = NeuronGroup(1, """dv/dt = (g-v)/(10*ms) : 1
+                            g : 1""", method='exact')
+H = NeuronGroup(10, 'V:1')
+
+S = Synapses(H, neurons,'''
+                dg_syn/dt = -g_syn/(100*ms) : 1 (clock-driven)
+                g_post = g_syn : 1 (summed)''')
+
+
+S.connect(True)
+run(101*ms)


### PR DESCRIPTION
This pull request is adding the feature of summed variables to Brian2Genn. In the wake of allowing summed variables, I also had to lift the restriction that every synapse has to have a post-synaptic effect (in the narrow sense of having a "post_write_var") as the post-synaptic effect could well come through a summed variable. I suspect that the use case in teili by @schlowm0 might re-invent what GeNN post-synapses do but for the moment I think this pull request removes a roadblock for using brian2genn from teili.
