### PR TITLE
[MRG] run_regularly operations on the CPU

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -398,7 +398,7 @@ class GeNNDevice(CPPStandaloneDevice):
         Processes abstract code into code objects and stores them in different
         arrays for `GeNNCodeObjects` and `GeNNUserCodeObjects`.
         '''
-        if name.endswith('_run_regularly_codeobject*'):
+        if '_run_regularly_' in name:
             variables['N'] = owner.variables['N']
             # Add an extra code object that executes the scalar code of
             # the run_regularly operation (will be directly called from
@@ -881,7 +881,7 @@ class GeNNDevice(CPPStandaloneDevice):
             # TODO: fix these freeze/CONSTANTS hacks somehow - they work but not elegant.
             if ((codeobj.template_name not in ['stateupdate', 'threshold',
                                                'reset', 'synapses']) or
-                    ('_run_regularly_codeobject' in codeobj.name)):
+                    ('_run_regularly_' in codeobj.name)):
                 if isinstance(codeobj.code, MultiTemplate):
                     code = freeze(codeobj.code.cpp_file, ns)
                     code = code.replace('%CONSTANTS%', '\n'.join(

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -1557,12 +1557,20 @@ class GeNNDevice(CPPStandaloneDevice):
                     'the dt used by the group.')
             step_value = int(run_regularly_dt / group_dt + 0.5)
             codeobj_read_write = self.run_regularly_read_write[run_reg.codeobj.name]
-            run_regularly_operations.append({'name': run_reg.name,
-                                             'codeobj': run_reg.codeobj,
-                                             'owner': run_reg.group,
-                                             'read': codeobj_read_write['read'],
-                                             'write': codeobj_read_write['write'],
-                                             'step': step_value})
+            op = {'name': run_reg.name,
+                  'codeobj': run_reg.codeobj,
+                  'owner': run_reg.group,
+                  'read': codeobj_read_write['read'],
+                  'write': codeobj_read_write['write'],
+                  'step': step_value,
+                  'isSynaptic': False}
+            if isinstance(run_reg.group, Synapses):
+                op['isSynaptic'] = True
+                op['srcN'] = run_reg.group.source.variables['N'].get_value()
+                op['trgN'] = run_reg.group.target.variables['N'].get_value()
+                op['connectivity'] = self.connectivityDict[run_reg.group.name]
+            run_regularly_operations.append(op)
+
         engine_tmp = GeNNCodeObject.templater.engine(None, None,
                                                      neuron_models=self.neuron_models,
                                                      spikegenerator_models=self.spikegenerator_models,

--- a/brian2genn/templates/engine.cpp
+++ b/brian2genn/templates/engine.cpp
@@ -108,81 +108,91 @@ void engine::run(double duration, //!< Duration of time to run the model for
   double elapsed_realtime;
 
   for (int i= 0; i < riT; i++) {
-      // report state
-      {% for sm in state_monitor_models %}
-      {% if sm.when == 'start' %}
-      {% for var in sm.variables %}
-      {% if sm.isSynaptic %}
-      {% if sm.connectivity == 'DENSE' %}
-      convert_dense_matrix_2_dynamic_arrays({{var}}{{sm.monitored}}, {{sm.srcN}}, {{sm.trgN}},brian::_dynamic_array_{{sm.monitored}}__synaptic_pre, brian::_dynamic_array_{{sm.monitored}}__synaptic_post, brian::_dynamic_array_{{sm.monitored}}_{{var}});
+      // The StateMonitor and run_regularly operations are ordered by their "order" value
+      {% for is_state_monitor, obj in run_reg_state_monitor_operations %}
+      {% if is_state_monitor %}
+      {% if obj.when == 'start' %}
+      {% for var in obj.variables %}
+      {% if obj.isSynaptic %}
+      {% if obj.connectivity == 'DENSE' %}
+      convert_dense_matrix_2_dynamic_arrays({{var}}{{obj.monitored}},
+                                            {{obj.srcN}}, {{obj.trgN}},
+                                            brian::_dynamic_array_{{obj.monitored}}__synaptic_pre,
+                                            brian::_dynamic_array_{{obj.monitored}}__synaptic_post,
+                                            brian::_dynamic_array_{{obj.monitored}}_{{var}});
       {% else %}
-      convert_sparse_synapses_2_dynamic_arrays(C{{sm.monitored}}, {{var}}{{sm.monitored}}, {{sm.srcN}}, {{sm.trgN}}, brian::_dynamic_array_{{sm.monitored}}__synaptic_pre, brian::_dynamic_array_{{sm.monitored}}__synaptic_post, brian::_dynamic_array_{{sm.monitored}}_{{var}}, b2g::FULL_MONTY);
+      convert_sparse_synapses_2_dynamic_arrays(C{{obj.monitored}},
+                                               {{var}}{{obj.monitored}},
+                                               {{obj.srcN}}, {{obj.trgN}},
+                                               brian::_dynamic_array_{{obj.monitored}}__synaptic_pre,
+                                               brian::_dynamic_array_{{obj.monitored}}__synaptic_post,
+                                               brian::_dynamic_array_{{obj.monitored}}_{{var}},
+                                               b2g::FULL_MONTY);
       {% endif %}
       {% else %}
-      copy_genn_to_brian({{var}}{{sm.monitored}}, brian::_array_{{sm.monitored}}_{{var}}, {{sm.N}});
+      copy_genn_to_brian({{var}}{{obj.monitored}}, brian::_array_{{obj.monitored}}_{{var}}, {{obj.N}});
       {% endif %}
       {% endfor %}
-      _run_{{sm.name}}_codeobject();
+      _run_{{obj.name}}_codeobject();
       {% endif %}
-      {% endfor %}
-      // Execute code for run_regularly operations (if any)
-      {% for run_reg in run_regularly_operations %}
-      if (i % {{run_reg['step']}} == 0)
+      {% else %}
+      if (i % {{obj['step']}} == 0)
       {
-          // Execute run_regularly operation: {{run_reg['name']}}
-          {% for var in run_reg['read'] %}
+          // Execute run_regularly operation: {{obj['name']}}
+          {% for var in obj['read'] %}
           {% if var == 't' %}
-          copy_genn_to_brian(&t, brian::_array_{{run_reg['owner'].clock.name}}_t, 1);
+          copy_genn_to_brian(&t, brian::_array_{{obj['owner'].clock.name}}_t, 1);
           {% elif var == 'dt' %}
           {# nothing to do #}
           {% else %}
-          {% if run_reg['isSynaptic'] %}
-          {% if run_reg['connectivity'] == 'DENSE' %}
-          convert_dense_matrix_2_dynamic_arrays({{var}}{{run_reg['owner'].name}},
-                                                {{run_reg['srcN']}}, {{run_reg['trgN']}},
-                                                brian::_dynamic_array_{{run_reg['owner'].name}}__synaptic_pre,
-                                                brian::_dynamic_array_{{run_reg['owner'].name}}__synaptic_post,
-                                                brian::_dynamic_array_{{run_reg['owner'].name}}_{{var}});
+          {% if obj['isSynaptic'] %}
+          {% if obj['connectivity'] == 'DENSE' %}
+          convert_dense_matrix_2_dynamic_arrays({{var}}{{obj['owner'].name}},
+                                                {{obj['srcN']}}, {{obj['trgN']}},
+                                                brian::_dynamic_array_{{obj['owner'].name}}__synaptic_pre,
+                                                brian::_dynamic_array_{{obj['owner'].name}}__synaptic_post,
+                                                brian::_dynamic_array_{{obj['owner'].name}}_{{var}});
           {% else %}
-          convert_sparse_synapses_2_dynamic_arrays(C{{run_reg['owner'].name}}, {{var}}{{run_reg['owner'].name}},
-                                                   {{run_reg['srcN']}}, {{run_reg['trgN']}},
-                                                   brian::_dynamic_array_{{run_reg['owner'].name}}__synaptic_pre,
-                                                   brian::_dynamic_array_{{run_reg['owner'].name}}__synaptic_post,
-                                                   brian::_dynamic_array_{{run_reg['owner'].name}}_{{var}}, b2g::FULL_MONTY);
+          convert_sparse_synapses_2_dynamic_arrays(C{{obj['owner'].name}}, {{var}}{{obj['owner'].name}},
+                                                   {{obj['srcN']}}, {{obj['trgN']}},
+                                                   brian::_dynamic_array_{{obj['owner'].name}}__synaptic_pre,
+                                                   brian::_dynamic_array_{{obj['owner'].name}}__synaptic_post,
+                                                   brian::_dynamic_array_{{obj['owner'].name}}_{{var}}, b2g::FULL_MONTY);
           {% endif %}
           {% else %}
-           copy_genn_to_brian({{var}}{{run_reg['owner'].name}},
-                              brian::_array_{{run_reg['owner'].name}}_{{var}},
-                              {{run_reg['owner'].variables[var].size}});
+           copy_genn_to_brian({{var}}{{obj['owner'].name}},
+                              brian::_array_{{obj['owner'].name}}_{{var}},
+                              {{obj['owner'].variables[var].size}});
           {% endif %}
           {% endif %}
           {% endfor %}
 
-          _run_{{run_reg['codeobj'].name}}();
+          _run_{{obj['codeobj'].name}}();
 
-           {% for var in run_reg['write'] %}
-           {% if run_reg['isSynaptic'] %}
-           {% if run_reg['connectivity'] == 'DENSE' %}
-           convert_dynamic_arrays_2_dense_matrix(brian::_dynamic_array_{{run_reg['owner'].name}}__synaptic_pre,
-                                                 brian::_dynamic_array_{{run_reg['owner'].name}}__synaptic_post,
-                                                 brian::_dynamic_array_{{run_reg['owner'].name}}_{{var}},
-                                                 {{var}}{{run_reg['owner'].name}},
-                                                 {{run_reg['srcN']}}, {{run_reg['trgN']}});
+           {% for var in obj['write'] %}
+           {% if obj['isSynaptic'] %}
+           {% if obj['connectivity'] == 'DENSE' %}
+           convert_dynamic_arrays_2_dense_matrix(brian::_dynamic_array_{{obj['owner'].name}}__synaptic_pre,
+                                                 brian::_dynamic_array_{{obj['owner'].name}}__synaptic_post,
+                                                 brian::_dynamic_array_{{obj['owner'].name}}_{{var}},
+                                                 {{var}}{{obj['owner'].name}},
+                                                 {{obj['srcN']}}, {{obj['trgN']}});
            {% else %}
-           convert_dynamic_arrays_2_sparse_synapses(brian::_dynamic_array_{{run_reg['owner'].name}}__synaptic_pre,
-                                                    brian::_dynamic_array_{{run_reg['owner'].name}}__synaptic_post,
-                                                    brian::_dynamic_array_{{run_reg['owner'].name}}_{{var}},
-                                                    {{var}}{{run_reg['owner'].name}},
-                                                    {{run_reg['srcN']}}, {{run_reg['trgN']}},
-                                                    _{{run_reg['owner'].name}}_bypre);
+           convert_dynamic_arrays_2_sparse_synapses(brian::_dynamic_array_{{obj['owner'].name}}__synaptic_pre,
+                                                    brian::_dynamic_array_{{obj['owner'].name}}__synaptic_post,
+                                                    brian::_dynamic_array_{{obj['owner'].name}}_{{var}},
+                                                    {{var}}{{obj['owner'].name}},
+                                                    {{obj['srcN']}}, {{obj['trgN']}},
+                                                    _{{obj['owner'].name}}_bypre);
            {% endif %}
            {% else %}
-           copy_brian_to_genn(brian::_array_{{run_reg['owner'].name}}_{{var}},
-                              {{var}}{{run_reg['owner'].name}},
-                              {{run_reg['owner'].variables[var].size}});
+           copy_brian_to_genn(brian::_array_{{obj['owner'].name}}_{{var}},
+                              {{var}}{{obj['owner'].name}},
+                              {{obj['owner'].variables[var].size}});
            {% endif %}
            {% endfor %}
       }
+      {% endif %}
       {% endfor %}
 #ifndef CPU_ONLY
       if (which == GPU) {

--- a/brian2genn/templates/main.cpp
+++ b/brian2genn/templates/main.cpp
@@ -75,7 +75,6 @@ int main(int argc, char *argv[])
   create_hidden_weightmatrix(brian::_dynamic_array_{{synapses.name}}__synaptic_pre, brian::_dynamic_array_{{synapses.name}}__synaptic_post, _hidden_weightmatrix{{synapses.name}},{{synapses.srcN}}, {{synapses.trgN}});
   {% else %} {# for sparse matrix representations #}
   allocate{{synapses.name}}(brian::_dynamic_array_{{synapses.name}}__synaptic_pre.size());
-  vector<vector<int32_t> > _{{synapses.name}}_bypre;
   initialize_sparse_synapses(brian::_dynamic_array_{{synapses.name}}__synaptic_pre, brian::_dynamic_array_{{synapses.name}}__synaptic_post,
                              C{{synapses.name}}, {{synapses.srcN}}, {{synapses.trgN}}, _{{synapses.name}}_bypre);
   {% for var in synapses.variables %}
@@ -225,6 +224,7 @@ using namespace std;
 
 #include "utils.h" // for CHECK_CUDA_ERRORS
 #include "stringUtils.h"
+#include <vector>
 
 #ifndef CPU_ONLY
 #include <cuda_runtime.h>
@@ -248,6 +248,10 @@ CStopWatch timer;
 
 //----------------------------------------------------------------------
 // other stuff:
-
-
+// global variables for pre-calculated list of the postsynaptic targets ordered by presynaptic sources
+{% for synapses in synapse_models %}
+{% if synapses.connectivity != 'DENSE' %}
+vector<vector<int32_t> > _{{synapses.name}}_bypre;
+{% endif %}
+{% endfor %}
 {% endmacro %}

--- a/brian2genn/templates/neuron_code.cpp
+++ b/brian2genn/templates/neuron_code.cpp
@@ -3,14 +3,6 @@
 // Update "constant over dt" subexpressions (if any)
 {{(scalar_code['subexpression_update'] + vector_code['subexpression_update'])|autoindent}}
 
-{% if has_run_regularly %}
-// Run regular operations on a slower clock
-int _timesteps = (int)(t/dt + 0.5);
-if (_timesteps % (int)_run_regularly_steps == 0) {  {# we need a type cast because GeNN parameters are double values #}
-    {{vector_code['run_regularly']|autoindent}}  {# Note that the scalar code (if any) is in a separate code object #}
-}
-{% endif %}
-
 // PoissonInputs targetting this group (if any)
 {{(scalar_code['poisson_input'] + vector_code['poisson_input'])|autoindent}}
 

--- a/brian2genn/templates/run_regularly_scalar_code.cpp
+++ b/brian2genn/templates/run_regularly_scalar_code.cpp
@@ -1,6 +1,0 @@
-{# ALLOWS_SCALAR_WRITE #}
-{% extends 'common_group.cpp' %}
-{% block maincode %}
-int _vectorisation_idx = -1;
-{{scalar_code['None']|autoindent}}
-{% endblock %}

--- a/docs_sphinx/introduction/exclusions.rst
+++ b/docs_sphinx/introduction/exclusions.rst
@@ -113,8 +113,9 @@ Timed arrays
 Timed arrays post a problem in the Brian2GeNN interface because they
 necessitate communication from the timed array to the target group at
 runtime that would result in host to GPU copies in the final CUDA/C++
-code. This could lead to large inefficiences and for the moment we
-have therefore decided to not support this feature.
+code. This could lead to large inefficiences, the use of ``TimedArray`` is therefore
+currently restricted to code in ``run_regularly`` operations that will be executed on
+the CPU.
 
 Multiple clocks
 ---------------


### PR DESCRIPTION
This PR still needs a bit more thorough testing, but it seems to work in principle. `run_regularly` operations are now always executed on the CPU, which comes with a number of advantages over the previous solution:
* Functions that are only available on the CPU can be used (most importantly, `TimedArray` #13).
* `Synapses` can have `run_regularly` operations as well (Fixes #58)
* More than one `run_regulary` operation per object allowed (not sure how relevant this is in practice, though).

If the user has a `run_regularly` operation that gets executed every time step, then the new approach will probably slow the simulation down a bit. For the more standard use case of a rarely executed operation, I don't think we'll see any difference.

Fixes #96.