### PR TITLE
[MRG] Compatibility fixes

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -568,16 +568,24 @@ class GeNNDevice(CPPStandaloneDevice):
         procedures = [('', main_lines)]
         runfuncs = {}
         for func, args in self.main_queue:
+            # explicitly exclude spike queue related code objects here:
+            if (func.endswith('run_code_object') and
+                    (args[0].name.endswith('_initialise_queue') or
+                     args[0].name.endswith('_push_spikes'))):
+                continue
             if func == 'run_code_object':
                 codeobj, = args
                 if self.run_statement_used:
                     raise NotImplementedError('Cannot execute code after the '
                                               'run statement '
                                               '(CodeObject: %s)' % codeobj.name)
-                # explicitly exclude spike queue related code objects here:
-                if not (codeobj.name.endswith('_initialise_queue') or
-                            (codeobj.name.endswith('_push_spikes'))):
-                    main_lines.append('_run_%s();' % codeobj.name)
+                main_lines.append('_run_%s();' % codeobj.name)
+            elif func == 'before_run_code_object':
+                codeobj, = args
+                main_lines.append('_before_run_%s();' % codeobj.name)
+            elif func == 'after_run_code_object':
+                codeobj, = args
+                main_lines.append('_after_run_%s();' % codeobj.name)
             elif func == 'run_network':
                 net, netcode = args
                 # do nothing

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -640,8 +640,7 @@ class GeNNDevice(CPPStandaloneDevice):
                 runfuncs[name] = main_lines
                 name, main_lines = procedures[-1]
             else:
-                raise NotImplementedError(
-                    "Unknown main queue function type " + func)
+                raise TypeError("Unknown main queue function type " + func)
 
         # generate the finalisations
         for codeobj in itervalues(self.code_objects):

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -647,6 +647,9 @@ class GeNNDevice(CPPStandaloneDevice):
                 name, main_lines = procedures.pop(-1)
                 runfuncs[name] = main_lines
                 name, main_lines = procedures[-1]
+            elif func == 'seed':
+                raise NotImplementedError('Setting a seed is currently '
+                                          'not supported')
             else:
                 raise TypeError("Unknown main queue function type " + func)
 


### PR DESCRIPTION
Using synapses with current Brian 2 master failed with a `NotImplementedError` related to Brian's spike queue (which we are not using in Brian2GeNN). Unfortunately, all errors of this kind lead to tests being marked as "skipped" instead of "failed", so I didn't notice it in the test runs earlier. This PR should fix this issue. It also raises a `TypeError` instead of a `NotImplementedError` in the previously failing situation, so similar errors shouldn't go unnoticed in the future. 