### PR TITLE
Support for GeNN 4 timing

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -330,11 +330,6 @@ class GeNNDevice(CPPStandaloneDevice):
         self.max_row_length_code_2= []
         self.max_row_length_vars= set()
         self.max_row_length_code_objects= {}
-        self.ktimer= dict()
-        self.ktimer['neuron_tme']= True
-        self.ktimer['synapse_tme']= False
-        self.ktimer['learning_tme']= False
-        self.ktimer['synDyn_tme']= False
         self.delays = {}
         self.spike_monitor_models = []
         self.rate_monitor_models = []
@@ -855,14 +850,7 @@ class GeNNDevice(CPPStandaloneDevice):
         self.process_poisson_groups(objects, poisson_groups)
         self.process_spikegenerators(spikegenerator_groups)
         self.process_synapses(synapse_groups, objects)
-        # need to establish which kernel timers will be created if kernel timing is desired
-        if len(self.synapse_models) > 0:
-            self.ktimer['synapse_tme']= True
-            for synapse_model in self.synapse_models:
-                if len(synapse_model.main_code_lines['post']) > 0:
-                    self.ktimer['learning_tme']= True
-                if len(synapse_model.main_code_lines['dynamics']) > 0:
-                    self.ktimer['dynamics_tme']= True
+        
         # Process monitors
         self.process_spike_monitors(spike_monitors)
         self.process_rate_monitors(rate_monitors)
@@ -1674,7 +1662,6 @@ class GeNNDevice(CPPStandaloneDevice):
                                                    header_files=header_files,
                                                    source_files=self.source_files,
                                                    prefs=prefs,
-                                                   ktimer=self.ktimer
                                                    )
         writer.write('main.*', runner_tmp)
 

--- a/brian2genn/templates/main.cpp
+++ b/brian2genn/templates/main.cpp
@@ -136,10 +136,8 @@ int main(int argc, char *argv[])
   //timer.stopTimer();
   cerr << t << " done ..." << endl;
   {% if prefs['devices.genn.kernel_timing'] %}
-  {% for kt in ('neuron_tme','synapse_tme','learning_tme','synDyn_tme') %}
-  {% if ktimer[kt] %}
+  {% for kt in ('neuronUpdateTime', 'presynapticUpdateTime', 'postsynapticUpdateTime', 'synapseDynamicsTime', 'initTime', 'initSparseTime') %}
   fprintf(timef,"%f ", {{kt}});
-  {% endif %}
   {% endfor %}
   {% endif %} 
   //fprintf(timef,"%f \n", timer.getElapsedTime());


### PR DESCRIPTION
GeNN 4 made the timing system slightly simpler to interact with but also renamed things. If kernel timing is enabled, the time file will contain 'neuronUpdateTime', 'presynapticUpdateTime', 'postsynapticUpdateTime', 'synapseDynamicsTime', 'initTime', 'initSparseTime'