### PR TITLE
Solution for multiple connect calls that lead to arrays 

### DIFF
--- a/examples/simple_example_with_synapses.py
+++ b/examples/simple_example_with_synapses.py
@@ -3,8 +3,8 @@ import brian2genn
 
 set_device('genn', directory='simple_example')
 
-Npre = 10000
-Npost= 1000
+Npre = 10
+Npost= 10
 tau = 10*ms
 Iin = 0.11/ms 
 eqs = '''
@@ -14,7 +14,6 @@ G = NeuronGroup(Npre, eqs, threshold='V>1', reset='V=0', refractory=5 * ms)
 G2= NeuronGroup(Npost, eqs, threshold='V>1', reset='V=0', refractory=5 * ms)
 
 S =Synapses(G, G2, 'w:1', on_pre='V+= w')
-S2 = Synapses(G2, G, 'w:1', on_pre='V+= w')
 S.connect(i=np.array([1, 3, 4, 2]), j=np.array([2, 2, 2, 2]))
-S2.connect(condition='i != j', p=0.5)
+S.connect(i=[1,2], j=[1,1])
 run(10*ms)


### PR DESCRIPTION
Ok ... here is a suggestion of how to fix the problem with multiple connect calls that lead to "array" type connections. This follows strategy 1 of doing it in Python.
However, it still does not work when connections are generated with connect calls where one call leads to an array on disk and another to a generator code_object.
In my mind there are two possibilities:

1. change tack and indeed load arrays in the buildmodel phase and count synapses aping the full synapse creation cycle of the eventual simulation.
2. make an upper bound by assuming all source (target) neurons have the max connections from the file based connectivity and add the connections from the created connectivity; this will overestimate the the max_row_length (max_col_length) but maybe that is acceptable?