### PR TITLE
Fix multiple connect v2

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -343,8 +343,8 @@ class GeNNDevice(CPPStandaloneDevice):
         self.spikegenerator_models = []
         self.synapse_models = []
         self.max_row_length_include= []
-        self.max_row_length_code_1= []
-        self.max_row_length_code_2= []
+        self.max_row_length_run_array= []
+        self.max_row_length_run_generator= []
         self.max_row_length_synapses= set()
         self.max_row_length_code_objects= {}
         self.delays = {}
@@ -535,9 +535,9 @@ class GeNNDevice(CPPStandaloneDevice):
                 # add _array run functions to the first code block, _generator ones to the
                 # second so that they are executed in the right order
                 if generator:
-                    self.max_row_length_code_2.append('_run_%s();' % mrl_name)
+                    self.max_row_length_run_generator.append('_run_%s();' % mrl_name)
                 else:
-                    self.max_row_length_code_1.append('_run_%s();' % mrl_name)
+                    self.max_row_length_run_array.append('_run_%s();' % mrl_name)
             codeobj = super(GeNNDevice, self).code_object(owner, name,
                                                           abstract_code,
                                                           variables,
@@ -1676,8 +1676,8 @@ class GeNNDevice(CPPStandaloneDevice):
                                                    synapse_models=self.synapse_models,
                                                    main_lines=dry_main_lines,
                                                    max_row_length_include= self.max_row_length_include,
-                                                   max_row_length_code_1=self.max_row_length_code_1,
-                                                   max_row_length_code_2=self.max_row_length_code_2,
+                                                   max_row_length_run_array=self.max_row_length_run_array,
+                                                   max_row_length_run_generator=self.max_row_length_run_generator,
                                                    max_row_length_synapses=self.max_row_length_synapses,
                                                    codeobj_inc=codeobj_inc,
                                                    dtDef=self.dtDef,

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -343,8 +343,7 @@ class GeNNDevice(CPPStandaloneDevice):
         self.spikegenerator_models = []
         self.synapse_models = []
         self.max_row_length_include= []
-        self.max_row_length_run_array= []
-        self.max_row_length_run_generator= []
+        self.max_row_length_run_calls= []
         self.max_row_length_synapses= set()
         self.max_row_length_code_objects= {}
         self.delays = {}
@@ -534,10 +533,8 @@ class GeNNDevice(CPPStandaloneDevice):
                 self.max_row_length_include.append('#include "code_objects/%s.cpp"' % codeobj.name)
                 # add _array run functions to the first code block, _generator ones to the
                 # second so that they are executed in the right order
-                if generator:
-                    self.max_row_length_run_generator.append('_run_%s();' % mrl_name)
-                else:
-                    self.max_row_length_run_array.append('_run_%s();' % mrl_name)
+                self.max_row_length_run_calls.append('_run_%s();' % mrl_name)
+
             codeobj = super(GeNNDevice, self).code_object(owner, name,
                                                           abstract_code,
                                                           variables,
@@ -1676,8 +1673,7 @@ class GeNNDevice(CPPStandaloneDevice):
                                                    synapse_models=self.synapse_models,
                                                    main_lines=dry_main_lines,
                                                    max_row_length_include= self.max_row_length_include,
-                                                   max_row_length_run_array=self.max_row_length_run_array,
-                                                   max_row_length_run_generator=self.max_row_length_run_generator,
+                                                   max_row_length_run_calls=self.max_row_length_run_calls,
                                                    max_row_length_synapses=self.max_row_length_synapses,
                                                    codeobj_inc=codeobj_inc,
                                                    dtDef=self.dtDef,

--- a/brian2genn/templates/max_row_length_array.cpp
+++ b/brian2genn/templates/max_row_length_array.cpp
@@ -46,7 +46,7 @@ void _run_{{codeobj_name}}()
 
     for (size_t _idx=0; _idx<_numsources; _idx++) {
       {# After this code has been executed, the arrays _real_sources and
-	  _real_variables contain the final indices. Having any code here it all is
+	  _real_targets contain the final indices. Having any code here it all is
 	  only necessary for supporting subgroups #}
       {{vector_code|autoindent}}
 

--- a/brian2genn/templates/max_row_length_array.cpp
+++ b/brian2genn/templates/max_row_length_array.cpp
@@ -34,9 +34,6 @@ void _run_{{codeobj_name}}()
     ///// POINTERS ////////////
     {{pointers_lines|autoindent}}
   
-    const size_t _old_num_synapses = {{N}};
-    const size_t _new_num_synapses = _old_num_synapses + _numsources;
-
     {# Get N_post and N_pre in the correct way, regardless of whether they are
 	constants or scalar arrays#}
     const size_t _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};

--- a/brian2genn/templates/max_row_length_array.cpp
+++ b/brian2genn/templates/max_row_length_array.cpp
@@ -1,0 +1,58 @@
+{# USES_VARIABLES { _synaptic_pre, _synaptic_post, sources, targets,
+                    N_incoming, N_outgoing, N,
+                    N_pre, N_post, _source_offset, _target_offset }
+#}
+{# WRITES_TO_READ_ONLY_VARIABLES { N_incoming, N_outgoing}
+#}
+
+#include "brianlib/common_math.h"
+#include "brianlib/stdint_compat.h"
+#include<cmath>
+#include<ctime>
+#include<iostream>
+#include<fstream>
+#include<climits>
+#include "brianlib/stdint_compat.h"
+#include "synapses_classes.h"
+
+////// SUPPORT CODE ///////
+namespace {{codeobj_name}}_array {
+	{{support_code_lines|autoindent}}
+}
+
+////// HASH DEFINES ///////
+{{hashdefine_lines|autoindent}}
+
+void _run_{{codeobj_name}}()
+{
+    using namespace brian;
+    using namespace {{codeobj_name}}_array;
+
+    ///// CONSTANTS ///////////
+    %CONSTANTS%
+
+    ///// POINTERS ////////////
+    {{pointers_lines|autoindent}}
+  
+    const size_t _old_num_synapses = {{N}};
+    const size_t _new_num_synapses = _old_num_synapses + _numsources;
+
+    {# Get N_post and N_pre in the correct way, regardless of whether they are
+	constants or scalar arrays#}
+    const size_t _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
+    const size_t _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
+    {{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
+    {{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
+
+    for (size_t _idx=0; _idx<_numsources; _idx++) {
+      {# After this code has been executed, the arrays _real_sources and
+	  _real_variables contain the final indices. Having any code here it all is
+	  only necessary for supporting subgroups #}
+      {{vector_code|autoindent}}
+
+      // Update the number of total outgoing/incoming synapses per source/target neuron
+      {{_dynamic_N_outgoing}}[_real_sources]++;
+      {{_dynamic_N_incoming}}[_real_targets]++;
+    }
+ }
+

--- a/brian2genn/templates/max_row_length_generator.cpp
+++ b/brian2genn/templates/max_row_length_generator.cpp
@@ -166,17 +166,4 @@ void _run_{{codeobj_name}}()
 	  }
         }
     
-	for (size_t _i= 0; _i < _N_pre; _i++) {
-	  long _pre_idx= _i + _source_offset;
-	  if (maxRow{{owner.name}} < {{_dynamic_N_outgoing}}[_pre_idx]) {
-	      maxRow{{owner.name}}= {{_dynamic_N_outgoing}}[_pre_idx];
-	  }
-	}
-	for (size_t _j= 0; _j < _N_post; _j++) {
-	  long _post_idx= _j + _target_offset;
-	  if (maxCol{{owner.name}} < {{_dynamic_N_incoming}}[_post_idx]) {
-	      maxCol{{owner.name}}= {{_dynamic_N_incoming}}[_post_idx];
-	  }
-	}
-
 }

--- a/brian2genn/templates/max_row_length_generator.cpp
+++ b/brian2genn/templates/max_row_length_generator.cpp
@@ -1,6 +1,8 @@
 {# USES_VARIABLES { _synaptic_pre, _synaptic_post, rand,
                     N_incoming, N_outgoing, N,
                     N_pre, N_post, _source_offset, _target_offset } #}
+{# WRITES_TO_READ_ONLY_VARIABLES { N_incoming, N_outgoing}
+#}
 
 #include "brianlib/common_math.h"
 #include "brianlib/stdint_compat.h"
@@ -13,7 +15,7 @@
 #include "synapses_classes.h"
 
 ////// SUPPORT CODE ///////
-namespace {{owner.name}}_max_row_length_generator {
+namespace {{codeobj_name}}_generator {
 	{{support_code_lines|autoindent}}
 }
 
@@ -23,16 +25,13 @@ namespace {{owner.name}}_max_row_length_generator {
 void _run_{{codeobj_name}}()
 {
     using namespace brian;
-    using namespace {{owner.name}}_max_row_length_generator;
+    using namespace  {{codeobj_name}}_generator;
 
     ///// CONSTANTS ///////////
     %CONSTANTS%
 
     ///// POINTERS ////////////
     {{pointers_lines|autoindent}}
-
-    maxRow{{owner.name}}= 1;
-    maxCol{{owner.name}}= 1;
 	
     {# Get N_post and N_pre in the correct way, regardless of whether they are
     constants or scalar arrays#}

--- a/brian2genn/templates/max_row_length_generator.cpp
+++ b/brian2genn/templates/max_row_length_generator.cpp
@@ -41,7 +41,7 @@ void _run_{{codeobj_name}}()
     {{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
     size_t _raw_pre_idx, _raw_post_idx;
     // scalar code
-    const size_t _vectorisation_idx = -1;
+    const int _vectorisation_idx = -1;
     {{scalar_code['setup_iterator']|autoindent}}
     {{scalar_code['create_j']|autoindent}}
     {{scalar_code['create_cond']|autoindent}}

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -182,11 +182,7 @@ void modelDefinition(NNmodel &model)
   //  for (int i=0; i<{{openmp_pragma('get_num_threads')}}; i++)
   //    brian::_mersenne_twister_states.push_back(new rk_state());
 
-  {% for max_row_length in max_row_length_run_array %}
-  {{max_row_length}}
-  {% endfor %}
-
-  {% for max_row_length in max_row_length_run_generator %}
+  {% for max_row_length in max_row_length_run_calls %}
   {{max_row_length}}
   {% endfor %}
 

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -14,8 +14,9 @@ double Network::_last_run_completed_fraction = 0.0;
 {{inc}}
 {% endfor %}
 
-{% for var in max_row_length_vars %}
-{{var}}
+{% for synapses in max_row_length_synapses %}
+long maxRow{{synapses}};
+long maxCol{{synapses}};
 {% endfor %}
 
 {% for inc in max_row_length_include %}
@@ -194,7 +195,21 @@ void modelDefinition(NNmodel &model)
   {{max_row_length}}
   {% endfor %}
 
-
+  {% for synapses in max_row_length_synapses %}
+  maxRow{{synapses}}= 1;
+  maxCol{{synapses}}= 1;
+  for (size_t Nrow : brian::_dynamic_array_{{synapses}}_N_outgoing) {
+    if (maxRow{{synapses}} < Nrow) {
+      maxRow{{synapses}}= Nrow;
+    }
+  }
+  for (size_t Ncol : brian::_dynamic_array_{{synapses}}_N_incoming) {
+    if (maxCol{{synapses}} < Ncol) {
+      maxCol{{synapses}}= Ncol;
+    }
+  }
+  {% endfor %}
+  
     {% if use_GPU %}
     // GENN_PREFERENCES set in brian2genn
     GENN_PREFERENCES.deviceSelectMethod = DeviceSelect::{{prefs['devices.genn.cuda_backend.device_select']}};

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -14,11 +14,6 @@ double Network::_last_run_completed_fraction = 0.0;
 {{inc}}
 {% endfor %}
 
-{% for synapses in max_row_length_synapses %}
-long maxRow{{synapses}};
-long maxCol{{synapses}};
-{% endfor %}
-
 {% for inc in max_row_length_include %}
 {{inc}}
 {% endfor %}
@@ -187,7 +182,7 @@ void modelDefinition(NNmodel &model)
   //  for (int i=0; i<{{openmp_pragma('get_num_threads')}}; i++)
   //    brian::_mersenne_twister_states.push_back(new rk_state());
 
-  {% for max_row_length in max_row_length_run_arrray %}
+  {% for max_row_length in max_row_length_run_array %}
   {{max_row_length}}
   {% endfor %}
 
@@ -196,18 +191,8 @@ void modelDefinition(NNmodel &model)
   {% endfor %}
 
   {% for synapses in max_row_length_synapses %}
-  maxRow{{synapses}}= 1;
-  maxCol{{synapses}}= 1;
-  for (size_t Nrow : brian::_dynamic_array_{{synapses}}_N_outgoing) {
-    if (maxRow{{synapses}} < Nrow) {
-      maxRow{{synapses}}= Nrow;
-    }
-  }
-  for (size_t Ncol : brian::_dynamic_array_{{synapses}}_N_incoming) {
-    if (maxCol{{synapses}} < Ncol) {
-      maxCol{{synapses}}= Ncol;
-    }
-  }
+  const long maxRow{{synapses}}= std::max(*std::max_element(brian::_dynamic_array_{{synapses}}_N_outgoing.begin(),brian::_dynamic_array_{{synapses}}_N_outgoing.end()),1);
+  const long maxCol{{synapses}}= std::max(*std::max_element(brian::_dynamic_array_{{synapses}}_N_incoming.begin(),brian::_dynamic_array_{{synapses}}_N_incoming.end()),1);
   {% endfor %}
   
     {% if use_GPU %}

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -161,11 +161,6 @@ IMPLEMENT_MODEL({{synapse_model.name}}POSTSYN);
 ){% endif %};
 {% endfor %}
 
-// need the brian style random numbers for calculating max row length and max col length
-//namespace brian {
-//  std::vector< rk_state* > _mersenne_twister_states;
-//}
-
 
 void modelDefinition(NNmodel &model)
 {
@@ -178,9 +173,6 @@ void modelDefinition(NNmodel &model)
 	  using namespace brian;
 	  {{ main_lines | autoindent }}
   }
-  //   // Random number generator states (need one for each thread in OpenMP)
-  //  for (int i=0; i<{{openmp_pragma('get_num_threads')}}; i++)
-  //    brian::_mersenne_twister_states.push_back(new rk_state());
 
   {% for max_row_length in max_row_length_run_calls %}
   {{max_row_length}}

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -187,11 +187,11 @@ void modelDefinition(NNmodel &model)
   //  for (int i=0; i<{{openmp_pragma('get_num_threads')}}; i++)
   //    brian::_mersenne_twister_states.push_back(new rk_state());
 
-  {% for max_row_length in max_row_length_code_1 %}
+  {% for max_row_length in max_row_length_run_arrray %}
   {{max_row_length}}
   {% endfor %}
 
-  {% for max_row_length in max_row_length_code_2 %}
+  {% for max_row_length in max_row_length_run_generator %}
   {{max_row_length}}
   {% endfor %}
 

--- a/examples/simple_example_with_synapses.py
+++ b/examples/simple_example_with_synapses.py
@@ -3,8 +3,8 @@ import brian2genn
 
 set_device('genn', directory='simple_example')
 
-Npre = 10000
-Npost= 1000
+Npre = 10
+Npost= 10
 tau = 10*ms
 Iin = 0.11/ms 
 eqs = '''
@@ -14,7 +14,6 @@ G = NeuronGroup(Npre, eqs, threshold='V>1', reset='V=0', refractory=5 * ms)
 G2= NeuronGroup(Npost, eqs, threshold='V>1', reset='V=0', refractory=5 * ms)
 
 S =Synapses(G, G2, 'w:1', on_pre='V+= w')
-S2 = Synapses(G2, G, 'w:1', on_pre='V+= w')
 S.connect(i=np.array([1, 3, 4, 2]), j=np.array([2, 2, 2, 2]))
-S2.connect(condition='i != j', p=0.5)
+S.connect(i=[1,2], j=[1,1])
 run(10*ms)


### PR DESCRIPTION
In this pull request I constructed a different way of solving the multiple connect calls issue. It is now doing all the max_row_length and max_col_length work in C++. For the connections created from arrays, a max_row_length_XXX_arrays code_object is run that apes the normal synapse creation from files. I also moved the actual max operation on all incoming and outgoing synapses numbers into the model.cpp template, which means it is only done once, not for every code object (connect call) repeatedly. To be honest, this is probably the cleaner solution and as we are already loading arrays anyway, it is probably as performant as the other, incomplete solution. I probably prefer it over #107 ...