### PR TITLE
Include custom headers in `model.cpp`

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -1647,7 +1647,8 @@ class GeNNDevice(CPPStandaloneDevice):
                                                    codeobj_inc=codeobj_inc,
                                                    dtDef=self.dtDef,
                                                    prefs=prefs,
-                                                   precision=precision
+                                                   precision=precision,
+                                                   header_files=prefs['codegen.cpp.headers']
                                                    )
         writer.write('magicnetwork_model.cpp', model_tmp)
 

--- a/brian2genn/templates/model.cpp
+++ b/brian2genn/templates/model.cpp
@@ -6,6 +6,15 @@
 
 #include "objects.h"
 #include "objects.cpp"
+
+{% for header in header_files %}
+{% if header.startswith('"') or header.startswith('<') %}
+#include {{header}}
+{% else %}
+#include "{{header}}"
+{% endif %}
+{% endfor %}
+
 // We need these to compile objects.cpp, but they are only used in _write_arrays which we never call.
 double Network::_last_run_time = 0.0;
 double Network::_last_run_completed_fraction = 0.0;


### PR DESCRIPTION
Fix for issue #131. I only included headers defined via `prefs.codegen.cpp.headers`.