### PR TITLE
This is a fix for issue #136. 

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -1590,8 +1590,16 @@ class GeNNDevice(CPPStandaloneDevice):
                 sm.when = 'end'
             if isinstance(src, Synapses):
                 sm.isSynaptic = True
-                sm.srcN = src.source.variables['N'].get_value()
-                sm.trgN = src.target.variables['N'].get_value()
+                neuron_src= src.source
+                # in brian2genn, we need the size of the entire pre-synaptic neuron population, not a sub-group size
+                if isinstance(neuron_src, Subgroup):
+                    neuron_src= neuron_src.source
+                sm.srcN = neuron_src.variables['N'].get_value()
+                neuron_trg= src.target
+                # in brian2genn, we need the size of the entire post-synaptic neuron population, not a sub-group size
+                if isinstance(neuron_trg, Subgroup):
+                    neuron_trg= neuron_trg.source
+                sm.trgN = neuron_trg.variables['N'].get_value()
                 sm.connectivity = self.connectivityDict[src.name]
             else:
                 sm.isSynaptic = False

--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -1588,15 +1588,15 @@ class GeNNDevice(CPPStandaloneDevice):
                 sm.when = 'end'
             if isinstance(src, Synapses):
                 sm.isSynaptic = True
-                neuron_src= src.source
+                neuron_src = src.source
                 # in brian2genn, we need the size of the entire pre-synaptic neuron population, not a sub-group size
                 if isinstance(neuron_src, Subgroup):
-                    neuron_src= neuron_src.source
+                    neuron_src = neuron_src.source
                 sm.srcN = neuron_src.variables['N'].get_value()
-                neuron_trg= src.target
+                neuron_trg = src.target
                 # in brian2genn, we need the size of the entire post-synaptic neuron population, not a sub-group size
                 if isinstance(neuron_trg, Subgroup):
-                    neuron_trg= neuron_trg.source
+                    neuron_trg = neuron_trg.source
                 sm.trgN = neuron_trg.variables['N'].get_value()
                 sm.connectivity = self.connectivityDict[src.name]
             else:


### PR DESCRIPTION
The root cause for the problem was that for situations where sub-populations of neuron populations were connected
and a state monitor for the synapses instantiated, the pre-template prep code would identify the size of the connected sub-populations for the ```srcN``` and ```trgN``` variables of the ```stateMonitorModel```. These variables are then used for the argument list of the ```convert_dense_matrix_2_dynamic_arrays``` and ```convert_sparse_synapses_2_dynamic_arrays``` calls that translate GeNN synaptic data into brian format synaptic data. Because brian2genn implements sub-populations only by connectivity matrices between full populations, the conversion functions need the size of the full populations, not of the connected sub-populations.
I believe the ```srcN``` and ```trgN``` variables are solely for the purpose of these conversions, so should not be needed to represent sub-population size elsewhere.