### PR TITLE
Support slow statemonitor clocks

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -294,6 +294,7 @@ class stateMonitorModel(object):
         self.srcN = 0
         self.trgN = 0
         self.when = ''
+        self.step = 1
         self.connectivity = ''
 
 
@@ -1610,6 +1611,21 @@ class GeNNDevice(CPPStandaloneDevice):
                         "variable '%s' is unused - not monitoring" % varname)
                 else:
                     sm.variables.append(varname)
+            if obj.clock.name != 'defaultclock':
+                obj_dt = obj.clock.dt_
+                source_dt = src.dt_[:]
+                if obj_dt < source_dt:
+                    raise NotImplementedError(
+                        'Brian2GeNN does not support StateMonitors '
+                        'with a dt smaller than the dt of the '
+                        'monitored object')
+                dt_mismatch = abs(((obj_dt + source_dt / 2) % source_dt) - source_dt / 2)
+                if dt_mismatch > 1e-4 * source_dt:
+                    raise NotImplementedError(
+                        'Brian2GeNN does not support StateMonitors '
+                        'with a dt that is not a multiple of the dt of the '
+                        'monitored object.')
+                sm.step = int(obj_dt / source_dt + 0.5)
 
             self.state_monitor_models.append(sm)
 
@@ -1803,7 +1819,7 @@ class GeNNDevice(CPPStandaloneDevice):
                 'Only a single run statement is supported for the genn device.')
         self.run_duration = float(duration)
         for obj in net.objects:
-            if obj.clock.name != 'defaultclock' and not (obj.__class__ == CodeRunner):
+            if (obj.clock.name != 'defaultclock') and (obj.__class__ not in (CodeRunner, StateMonitor)):
                 raise NotImplementedError(
                     'Multiple clocks are not supported for the genn device')
 

--- a/brian2genn/templates/engine.cpp
+++ b/brian2genn/templates/engine.cpp
@@ -85,40 +85,41 @@ void engine::run(double duration)  //!< Duration of time to run the model for
   for (int i= 0; i < riT; i++) {
     // The StateMonitor and run_regularly operations are ordered by their "order" value
         {% for is_state_monitor, obj in run_reg_state_monitor_operations %}
+    if (i % {{obj['step']}} == 0)
+    {
           {% if is_state_monitor %}
+      // Execute state monitor operation: {{obj['name']}}
             {% if obj.when == 'start' %}
               {% for var in obj.variables %}
                 {% if obj.isSynaptic %}
                   {% if obj.connectivity == 'DENSE' %}
-    convert_dense_matrix_2_dynamic_arrays({{var}}{{obj.monitored}},
-                                          {{obj.srcN}}, {{obj.trgN}},
-                                          brian::_dynamic_array_{{obj.monitored}}__synaptic_pre,
-                                          brian::_dynamic_array_{{obj.monitored}}__synaptic_post,
-                                          brian::_dynamic_array_{{obj.monitored}}_{{var}});
+      convert_dense_matrix_2_dynamic_arrays({{var}}{{obj.monitored}},
+                                            {{obj.srcN}}, {{obj.trgN}},
+                                            brian::_dynamic_array_{{obj.monitored}}__synaptic_pre,
+                                            brian::_dynamic_array_{{obj.monitored}}__synaptic_post,
+                                            brian::_dynamic_array_{{obj.monitored}}_{{var}});
                   {% else %}
-    convert_sparse_synapses_2_dynamic_arrays(rowLength{{obj.monitored}},
-                                             ind{{obj.monitored}},
-                                             maxRowLength{{obj.monitored}},
-                                             {{var}}{{obj.monitored}},
-                                             {{obj.srcN}}, {{obj.trgN}},
-                                             brian::_dynamic_array_{{obj.monitored}}__synaptic_pre,
-                                             brian::_dynamic_array_{{obj.monitored}}__synaptic_post,
-                                             brian::_dynamic_array_{{obj.monitored}}_{{var}},
-                                                     b2g::FULL_MONTY);
+      convert_sparse_synapses_2_dynamic_arrays(rowLength{{obj.monitored}},
+                                               ind{{obj.monitored}},
+                                               maxRowLength{{obj.monitored}},
+                                               {{var}}{{obj.monitored}},
+                                               {{obj.srcN}}, {{obj.trgN}},
+                                               brian::_dynamic_array_{{obj.monitored}}__synaptic_pre,
+                                               brian::_dynamic_array_{{obj.monitored}}__synaptic_post,
+                                               brian::_dynamic_array_{{obj.monitored}}_{{var}},
+                                               b2g::FULL_MONTY);
                   {% endif %}
                 {% else %}
                   {% if obj.src.variables[var].scalar %}
-    *brian::_array_{{obj.monitored}}_{{var}} = {{var}}{{obj.monitored}};
+      *brian::_array_{{obj.monitored}}_{{var}} = {{var}}{{obj.monitored}};
                   {% else %}
-    std::copy_n({{var}}{{obj.monitored}}, {{obj.N}}, brian::_array_{{obj.monitored}}_{{var}});
+      std::copy_n({{var}}{{obj.monitored}}, {{obj.N}}, brian::_array_{{obj.monitored}}_{{var}});
                   {% endif %}
                 {% endif %}
               {% endfor %}
-    _run_{{obj.codeobject_name}}();
+      _run_{{obj.codeobject_name}}();
             {% endif %}
           {% else %}
-    if (i % {{obj['step']}} == 0)
-    {
       // Execute run_regularly operation: {{obj['name']}}
             {% for var in obj['read'] %}
               {% if var == 't' %}
@@ -178,8 +179,8 @@ void engine::run(double duration)  //!< Duration of time to run the model for
                 {% endif %}
               {% endif %}
             {% endfor %}
-    }
           {% endif %}
+    }
         {% endfor %}
         {% set states_pushed = [] %}
         {% for run_reg in run_regularly_operations %}
@@ -246,34 +247,38 @@ void engine::run(double duration)  //!< Duration of time to run the model for
     // report state
         {% for sm in state_monitor_models %}
           {% if sm.when != 'start' %}
+    if (i % {{sm['step']}} == 0)
+    {
+      // Execute state monitor operation: {{sm['name']}}
             {% for var in sm.variables %}
               {% if sm.isSynaptic %}
                 {% if sm.connectivity == 'DENSE' %}
-    convert_dense_matrix_2_dynamic_arrays({{var}}{{sm.monitored}},
-                                          {{sm.srcN}}, {{sm.trgN}},
-                                          brian::_dynamic_array_{{sm.monitored}}__synaptic_pre,
-                                          brian::_dynamic_array_{{sm.monitored}}__synaptic_post,
-                                          brian::_dynamic_array_{{sm.monitored}}_{{var}});
+      convert_dense_matrix_2_dynamic_arrays({{var}}{{sm.monitored}},
+                                            {{sm.srcN}}, {{sm.trgN}},
+                                            brian::_dynamic_array_{{sm.monitored}}__synaptic_pre,
+                                            brian::_dynamic_array_{{sm.monitored}}__synaptic_post,
+                                            brian::_dynamic_array_{{sm.monitored}}_{{var}});
                 {% else %}
-    convert_sparse_synapses_2_dynamic_arrays(rowLength{{sm.monitored}},
-                                             ind{{sm.monitored}},
-                                             maxRowLength{{sm.monitored}},
-                                             {{var}}{{sm.monitored}},
-                                             {{sm.srcN}}, {{sm.trgN}},
-                                             brian::_dynamic_array_{{sm.monitored}}__synaptic_pre,
-                                             brian::_dynamic_array_{{sm.monitored}}__synaptic_post,
-                                             brian::_dynamic_array_{{sm.monitored}}_{{var}},
-                                             b2g::FULL_MONTY);
+      convert_sparse_synapses_2_dynamic_arrays(rowLength{{sm.monitored}},
+                                               ind{{sm.monitored}},
+                                               maxRowLength{{sm.monitored}},
+                                               {{var}}{{sm.monitored}},
+                                               {{sm.srcN}}, {{sm.trgN}},
+                                               brian::_dynamic_array_{{sm.monitored}}__synaptic_pre,
+                                               brian::_dynamic_array_{{sm.monitored}}__synaptic_post,
+                                               brian::_dynamic_array_{{sm.monitored}}_{{var}},
+                                               b2g::FULL_MONTY);
                 {% endif %}
               {% else %}
                 {% if sm.src.variables[var].scalar %}
-    *brian::_array_{{sm.monitored}}_{{var}} = {{var}}{{sm.monitored}};
+      *brian::_array_{{sm.monitored}}_{{var}} = {{var}}{{sm.monitored}};
                 {% else %}
-    std::copy_n({{var}}{{sm.monitored}}, {{sm.N}}, brian::_array_{{sm.monitored}}_{{var}});
+      std::copy_n({{var}}{{sm.monitored}}, {{sm.N}}, brian::_array_{{sm.monitored}}_{{var}});
                 {% endif %}
               {% endif %}
             {% endfor %}
-    _run_{{sm.codeobject_name}}();
+      _run_{{sm.codeobject_name}}();
+    }
           {% endif %}
         {% endfor %}
     // report spikes

--- a/brian2genn/templates/engine.cpp
+++ b/brian2genn/templates/engine.cpp
@@ -25,14 +25,14 @@ double Network::_last_run_completed_fraction = 0.0;
 class engine
 {
  public:
-  // end of data fields 
+  // end of data fields
 
   engine();
   ~engine();
-  void free_device_mem(); 
+  void free_device_mem();
   void run(double);
-  void getStateFromGPU(); 
-  void getSpikesFromGPU(); 
+  void getStateFromGPU();
+  void getSpikesFromGPU();
 };
 
 #endif
@@ -75,7 +75,7 @@ engine::~engine()
 
 void engine::run(double duration)  //!< Duration of time to run the model for
 {
-  std::clock_t start, current; 
+  std::clock_t start, current;
   const double t_start = t;
 
   start = std::clock();
@@ -83,216 +83,233 @@ void engine::run(double duration)  //!< Duration of time to run the model for
   double elapsed_realtime;
 
   for (int i= 0; i < riT; i++) {
-      // The StateMonitor and run_regularly operations are ordered by their "order" value
-      {% for is_state_monitor, obj in run_reg_state_monitor_operations %}
-      {% if is_state_monitor %}
-      {% if obj.when == 'start' %}
-      {% for var in obj.variables %}
-      {% if obj.isSynaptic %}
-      {% if obj.connectivity == 'DENSE' %}
-      convert_dense_matrix_2_dynamic_arrays({{var}}{{obj.monitored}},
-                                            {{obj.srcN}}, {{obj.trgN}},
-                                            brian::_dynamic_array_{{obj.monitored}}__synaptic_pre,
-                                            brian::_dynamic_array_{{obj.monitored}}__synaptic_post,
-                                            brian::_dynamic_array_{{obj.monitored}}_{{var}});
-      {% else %}
-      convert_sparse_synapses_2_dynamic_arrays(rowLength{{obj.monitored}},
-					       ind{{obj.monitored}},
-					       maxRowLength{{obj.monitored}},
-                                               {{var}}{{obj.monitored}},
-                                               {{obj.srcN}}, {{obj.trgN}},
-                                               brian::_dynamic_array_{{obj.monitored}}__synaptic_pre,
-                                               brian::_dynamic_array_{{obj.monitored}}__synaptic_post,
-                                               brian::_dynamic_array_{{obj.monitored}}_{{var}},
-                                               b2g::FULL_MONTY);
-      {% endif %}
-      {% else %}
-      {% if obj.src.variables[var].scalar %}
-      *brian::_array_{{obj.monitored}}_{{var}} = {{var}}{{obj.monitored}};
-      {% else %}
-      std::copy_n({{var}}{{obj.monitored}}, {{obj.N}}, brian::_array_{{obj.monitored}}_{{var}});
-      {% endif %}
-      {% endif %}
-      {% endfor %}
-      _run_{{obj.codeobject_name}}();
-      {% endif %}
-      {% else %}
-      if (i % {{obj['step']}} == 0)
-      {
-          // Execute run_regularly operation: {{obj['name']}}
-          {% for var in obj['read'] %}
-        {% if var == 't' %}
-        std::copy_n(&t, 1, brian::_array_{{obj['owner'].clock.name}}_t);
-        {% elif var == 'dt' %}
-        {# nothing to do #}
-        {% else %}
-          {% if obj['isSynaptic'] %}
-          {% if obj['connectivity'] == 'DENSE' %}
-          convert_dense_matrix_2_dynamic_arrays({{var}}{{obj['owner'].name}},
-                                                {{obj['srcN']}}, {{obj['trgN']}},
-                                                brian::_dynamic_array_{{obj['owner'].name}}__synaptic_pre,
-                                                brian::_dynamic_array_{{obj['owner'].name}}__synaptic_post,
-                                                brian::_dynamic_array_{{obj['owner'].name}}_{{var}});
+    // The StateMonitor and run_regularly operations are ordered by their "order" value
+        {% for is_state_monitor, obj in run_reg_state_monitor_operations %}
+          {% if is_state_monitor %}
+            {% if obj.when == 'start' %}
+              {% for var in obj.variables %}
+                {% if obj.isSynaptic %}
+                  {% if obj.connectivity == 'DENSE' %}
+    convert_dense_matrix_2_dynamic_arrays({{var}}{{obj.monitored}},
+                                          {{obj.srcN}}, {{obj.trgN}},
+                                          brian::_dynamic_array_{{obj.monitored}}__synaptic_pre,
+                                          brian::_dynamic_array_{{obj.monitored}}__synaptic_post,
+                                          brian::_dynamic_array_{{obj.monitored}}_{{var}});
+                  {% else %}
+    convert_sparse_synapses_2_dynamic_arrays(rowLength{{obj.monitored}},
+                                             ind{{obj.monitored}},
+                                             maxRowLength{{obj.monitored}},
+                                             {{var}}{{obj.monitored}},
+                                             {{obj.srcN}}, {{obj.trgN}},
+                                             brian::_dynamic_array_{{obj.monitored}}__synaptic_pre,
+                                             brian::_dynamic_array_{{obj.monitored}}__synaptic_post,
+                                             brian::_dynamic_array_{{obj.monitored}}_{{var}},
+                                                     b2g::FULL_MONTY);
+                  {% endif %}
+                {% else %}
+                  {% if obj.src.variables[var].scalar %}
+    *brian::_array_{{obj.monitored}}_{{var}} = {{var}}{{obj.monitored}};
+                  {% else %}
+    std::copy_n({{var}}{{obj.monitored}}, {{obj.N}}, brian::_array_{{obj.monitored}}_{{var}});
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
+    _run_{{obj.codeobject_name}}();
+            {% endif %}
           {% else %}
-          convert_sparse_synapses_2_dynamic_arrays(rowLength{{obj['owner'].name}},
-		                                   ind{{obj['owner'].name}},
-						   maxRowLength{{obj['owner'].name}},
-		                                   {{var}}{{obj['owner'].name}},
-                                                   {{obj['srcN']}}, {{obj['trgN']}},
-                                                   brian::_dynamic_array_{{obj['owner'].name}}__synaptic_pre,
-                                                   brian::_dynamic_array_{{obj['owner'].name}}__synaptic_post,
-                                                   brian::_dynamic_array_{{obj['owner'].name}}_{{var}}, b2g::FULL_MONTY);
-          {% endif %}
-          {% else %}
-	  {% if obj['owner'].variables[var].scalar %}
-	  *brian::_array_{{obj['owner'].name}}_{{var}} = {{var}}{{obj['owner'].name}};
-	  {% else %}
-           std::copy_n({{var}}{{obj['owner'].name}}, {{obj['owner'].variables[var].size}},
-                       brian::_array_{{obj['owner'].name}}_{{var}});
-	   {% endif %}
-          {% endif %}
-        {% endif %}
-        {% endfor %}
-
-          _run_{{obj['codeobj'].name}}();
-
-           {% for var in obj['write'] %}
-           {% if obj['isSynaptic'] %}
-           {% if obj['connectivity'] == 'DENSE' %}
-           convert_dynamic_arrays_2_dense_matrix(brian::_dynamic_array_{{obj['owner'].name}}__synaptic_pre,
-                                                 brian::_dynamic_array_{{obj['owner'].name}}__synaptic_post,
-                                                 brian::_dynamic_array_{{obj['owner'].name}}_{{var}},
-                                                 {{var}}{{obj['owner'].name}},
-                                                 {{obj['srcN']}}, {{obj['trgN']}});
-           {% else %}
-           convert_dynamic_arrays_2_sparse_synapses(brian::_dynamic_array_{{obj['owner'].name}}_{{var}},
-						    sparseSynapseIndices{{obj['owner'].name}},
-                                                    {{var}}{{obj['owner'].name}},
-                                                    {{obj['srcN']}}, {{obj['trgN']}});
-           {% endif %}
-           {% else %}
-	   {% if obj['owner'].variables[var].scalar %}
-	   {{var}}{{obj['owner'].name}} = *brian::_array_{{obj['owner'].name}}_{{var}};
-	   {% else %}
-           std::copy_n(brian::_array_{{obj['owner'].name}}_{{var}}, {{obj['owner'].variables[var].size}}, {{var}}{{obj['owner'].name}});
-	   {% endif %}
-           {% endif %}
-        {% endfor %}
-      }
-      {% endif %}
-      {% endfor %}
-      {% set states_pushed = [] %}
-      {% for run_reg in run_regularly_operations %}
-      if (i % {{run_reg['step']}} == 0)  // only push state if we executed the operation
-      {
-          {% for var in run_reg['write'] %}
-              {% if not run_reg['owner'].variables[var].owner.name in states_pushed %}
-              push{{run_reg['owner'].variables[var].owner.name}}StateToDevice();
-              {% if states_pushed.append(run_reg['owner'].variables[var].owner.name) %}{% endif %}
+    if (i % {{obj['step']}} == 0)
+    {
+      // Execute run_regularly operation: {{obj['name']}}
+            {% for var in obj['read'] %}
+              {% if var == 't' %}
+      std::copy_n(&t, 1, brian::_array_{{obj['owner'].clock.name}}_t);
+              {% elif var == 'dt' %}
+                {# nothing to do #}
+              {% else %}
+                {% if obj['isSynaptic'] %}
+                  {% if obj['connectivity'] == 'DENSE' %}
+      convert_dense_matrix_2_dynamic_arrays({{var}}{{obj['owner'].name}},
+                                            {{obj['srcN']}}, {{obj['trgN']}},
+                                            brian::_dynamic_array_{{obj['owner'].name}}__synaptic_pre,
+                                            brian::_dynamic_array_{{obj['owner'].name}}__synaptic_post,
+                                            brian::_dynamic_array_{{obj['owner'].name}}_{{var}});
+                  {% else %}
+      convert_sparse_synapses_2_dynamic_arrays(rowLength{{obj['owner'].name}},
+                                               ind{{obj['owner'].name}},
+                                               maxRowLength{{obj['owner'].name}},
+                                               {{var}}{{obj['owner'].name}},
+                                               {{obj['srcN']}}, {{obj['trgN']}},
+                                               brian::_dynamic_array_{{obj['owner'].name}}__synaptic_pre,
+                                               brian::_dynamic_array_{{obj['owner'].name}}__synaptic_post,
+                                               brian::_dynamic_array_{{obj['owner'].name}}_{{var}}, b2g::FULL_MONTY);
+                  {% endif %}
+                {% else %}
+                  {% if obj['owner'].variables[var].scalar %}
+      *brian::_array_{{obj['owner'].name}}_{{var}} = {{var}}{{obj['owner'].name}};
+                  {% else %}
+      std::copy_n({{var}}{{obj['owner'].name}}, {{obj['owner'].variables[var].size}},
+      brian::_array_{{obj['owner'].name}}_{{var}});
+                  {% endif %}
+                {% endif %}
               {% endif %}
-          {% endfor %}
-      }
-      {% endfor %}
-      stepTime();
-      // The stepTimeGPU function already updated everything for the next time step
-      iT--;
-      t = iT*DT;
-      {% for spkGen in spikegenerator_models %}
-      _run_{{spkGen.codeobject_name}}();
-      push{{spkGen.name}}SpikesToDevice();
-      {% endfor %}
-      {% set spikes_pulled = [] %}
-      {% for spkMon in spike_monitor_models %}
-      {% if (spkMon.notSpikeGeneratorGroup) %}
-      {% if not spkMon.neuronGroup in spikes_pulled %}
-      pull{{spkMon.neuronGroup}}CurrentSpikesFromDevice();
-      {% if spikes_pulled.append(spkMon.neuronGroup) %}{% endif %}
-      {% endif %}
-      {% endif %}
-      {% endfor %}
-      {% for rateMon in rate_monitor_models %}
-      {% if (rateMon.notSpikeGeneratorGroup) %}
-      {% if not rateMon.neuronGroup in spikes_pulled %}
-      pull{{rateMon.neuronGroup}}CurrentSpikesFromDevice();
-      {% if spikes_pulled.append(rateMon.neuronGroup) %}{% endif %}
-      {% endif %}
-      {% endif %}
-      {% endfor %}
-      {% set states_pulled = [] %}
-      {% for sm in state_monitor_models %}
-      {% if not sm.monitored in states_pulled %}
-      pull{{sm.monitored}}StateFromDevice();
-      {% if states_pulled.append(sm.monitored) %}{% endif %}
-      {% endif %}
-      {% endfor %}
-      {% for run_reg in run_regularly_operations %}
-        if ((i + 1) % {{run_reg['step']}} == 0)  // only pull state if next time step executes operation
-        {
-            {% for var in run_reg['read'] %}
-            {% if not var in ['t', 'dt'] %}
-            {% if not run_reg['owner'].variables[var].owner.name in states_pulled %}
-            pull{{run_reg['owner'].variables[var].owner.name}}StateFromDevice();
-            {% if states_pulled.append(run_reg['owner'].variables[var].owner.name) %}{% endif %}
-            {% endif %}
-            {% endif %}
             {% endfor %}
-        }
-      {% endfor %}
-      // report state 
-      {% for sm in state_monitor_models %}
-      {% if sm.when != 'start' %}
-      {% for var in sm.variables %}
-      {% if sm.isSynaptic %}
-      {% if sm.connectivity == 'DENSE' %}
-      convert_dense_matrix_2_dynamic_arrays({{var}}{{sm.monitored}}, {{sm.srcN}}, {{sm.trgN}},brian::_dynamic_array_{{sm.monitored}}__synaptic_pre, brian::_dynamic_array_{{sm.monitored}}__synaptic_post, brian::_dynamic_array_{{sm.monitored}}_{{var}});
-      {% else %}
-      convert_sparse_synapses_2_dynamic_arrays(rowLength{{sm.monitored}}, ind{{sm.monitored}}, maxRowLength{{sm.monitored}}, {{var}}{{sm.monitored}}, {{sm.srcN}}, {{sm.trgN}}, brian::_dynamic_array_{{sm.monitored}}__synaptic_pre, brian::_dynamic_array_{{sm.monitored}}__synaptic_post, brian::_dynamic_array_{{sm.monitored}}_{{var}}, b2g::FULL_MONTY);
-      {% endif %}
-      {% else %}
-      {% if sm.src.variables[var].scalar %}
-      *brian::_array_{{sm.monitored}}_{{var}} = {{var}}{{sm.monitored}};
-      {% else %}
-      std::copy_n({{var}}{{sm.monitored}}, {{sm.N}}, brian::_array_{{sm.monitored}}_{{var}});
-      {% endif %}
-      {% endif %}
-      {% endfor %}
-      _run_{{sm.codeobject_name}}();
-      {% endif %}
-      {% endfor %}
-      // report spikes
-      {% for spkMon in spike_monitor_models %}
-      _run_{{spkMon.codeobject_name}}();
-      {% endfor %}
-      {% for rateMon in rate_monitor_models %}
-      _run_{{rateMon.codeobject_name}}();
-      {% endfor %}
-      // Bring the time step back to the value for the next loop iteration
-      iT++;
-      t = iT*DT;
-      {% if maximum_run_time is not none %}
-      current= std::clock();
-      elapsed_realtime= (double) (current - start)/CLOCKS_PER_SEC;
-      if (elapsed_realtime > {{maximum_run_time}}) {
-        break;
-      }
-      {% endif %}
-  }  
-  {% if maximum_run_time is none %}
+
+      _run_{{obj['codeobj'].name}}();
+
+            {% for var in obj['write'] %}
+              {% if obj['isSynaptic'] %}
+                {% if obj['connectivity'] == 'DENSE' %}
+      convert_dynamic_arrays_2_dense_matrix(brian::_dynamic_array_{{obj['owner'].name}}__synaptic_pre,
+                                            brian::_dynamic_array_{{obj['owner'].name}}__synaptic_post,
+                                            brian::_dynamic_array_{{obj['owner'].name}}_{{var}},
+                                            {{var}}{{obj['owner'].name}},
+                                            {{obj['srcN']}}, {{obj['trgN']}});
+                {% else %}
+      convert_dynamic_arrays_2_sparse_synapses(brian::_dynamic_array_{{obj['owner'].name}}_{{var}},
+                                               sparseSynapseIndices{{obj['owner'].name}},
+                                               {{var}}{{obj['owner'].name}},
+                                               {{obj['srcN']}}, {{obj['trgN']}});
+                {% endif %}
+              {% else %}
+                {% if obj['owner'].variables[var].scalar %}
+      {{var}}{{obj['owner'].name}} = *brian::_array_{{obj['owner'].name}}_{{var}};
+                {% else %}
+      std::copy_n(brian::_array_{{obj['owner'].name}}_{{var}}, {{obj['owner'].variables[var].size}}, {{var}}{{obj['owner'].name}});
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+    }
+          {% endif %}
+        {% endfor %}
+        {% set states_pushed = [] %}
+        {% for run_reg in run_regularly_operations %}
+    if (i % {{run_reg['step']}} == 0)  // only push state if we executed the operation
+    {
+          {% for var in run_reg['write'] %}
+            {% if not run_reg['owner'].variables[var].owner.name in states_pushed %}
+      push{{run_reg['owner'].variables[var].owner.name}}StateToDevice();
+              {% if states_pushed.append(run_reg['owner'].variables[var].owner.name) %}
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+    }
+        {% endfor %}
+    stepTime();
+    // The stepTimeGPU function already updated everything for the next time step
+    iT--;
+    t = iT*DT;
+        {% for spkGen in spikegenerator_models %}
+    _run_{{spkGen.codeobject_name}}();
+    push{{spkGen.name}}SpikesToDevice();
+        {% endfor %}
+        {% set spikes_pulled = [] %}
+        {% for spkMon in spike_monitor_models %}
+          {% if (spkMon.notSpikeGeneratorGroup) %}
+            {% if not spkMon.neuronGroup in spikes_pulled %}
+    pull{{spkMon.neuronGroup}}CurrentSpikesFromDevice();
+              {% if spikes_pulled.append(spkMon.neuronGroup) %}
+              {% endif %}
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+        {% for rateMon in rate_monitor_models %}
+          {% if (rateMon.notSpikeGeneratorGroup) %}
+            {% if not rateMon.neuronGroup in spikes_pulled %}
+    pull{{rateMon.neuronGroup}}CurrentSpikesFromDevice();
+              {% if spikes_pulled.append(rateMon.neuronGroup) %}
+              {% endif %}
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+        {% set states_pulled = [] %}
+        {% for sm in state_monitor_models %}
+          {% if not sm.monitored in states_pulled %}
+    pull{{sm.monitored}}StateFromDevice();
+            {% if states_pulled.append(sm.monitored) %}
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+        {% for run_reg in run_regularly_operations %}
+    if ((i + 1) % {{run_reg['step']}} == 0)  // only pull state if next time step executes operation
+    {
+          {% for var in run_reg['read'] %}
+            {% if not var in ['t', 'dt'] %}
+              {% if not run_reg['owner'].variables[var].owner.name in states_pulled %}
+      pull{{run_reg['owner'].variables[var].owner.name}}StateFromDevice();
+                {% if states_pulled.append(run_reg['owner'].variables[var].owner.name) %}
+                {% endif %}
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+    }
+        {% endfor %}
+    // report state
+        {% for sm in state_monitor_models %}
+          {% if sm.when != 'start' %}
+            {% for var in sm.variables %}
+              {% if sm.isSynaptic %}
+                {% if sm.connectivity == 'DENSE' %}
+    convert_dense_matrix_2_dynamic_arrays({{var}}{{sm.monitored}},
+                                          {{sm.srcN}}, {{sm.trgN}},
+                                          brian::_dynamic_array_{{sm.monitored}}__synaptic_pre,
+                                          brian::_dynamic_array_{{sm.monitored}}__synaptic_post,
+                                          brian::_dynamic_array_{{sm.monitored}}_{{var}});
+                {% else %}
+    convert_sparse_synapses_2_dynamic_arrays(rowLength{{sm.monitored}},
+                                             ind{{sm.monitored}},
+                                             maxRowLength{{sm.monitored}},
+                                             {{var}}{{sm.monitored}},
+                                             {{sm.srcN}}, {{sm.trgN}},
+                                             brian::_dynamic_array_{{sm.monitored}}__synaptic_pre,
+                                             brian::_dynamic_array_{{sm.monitored}}__synaptic_post,
+                                             brian::_dynamic_array_{{sm.monitored}}_{{var}},
+                                             b2g::FULL_MONTY);
+                {% endif %}
+              {% else %}
+                {% if sm.src.variables[var].scalar %}
+    *brian::_array_{{sm.monitored}}_{{var}} = {{var}}{{sm.monitored}};
+                {% else %}
+    std::copy_n({{var}}{{sm.monitored}}, {{sm.N}}, brian::_array_{{sm.monitored}}_{{var}});
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+    _run_{{sm.codeobject_name}}();
+          {% endif %}
+        {% endfor %}
+    // report spikes
+        {% for spkMon in spike_monitor_models %}
+    _run_{{spkMon.codeobject_name}}();
+        {% endfor %}
+        {% for rateMon in rate_monitor_models %}
+    _run_{{rateMon.codeobject_name}}();
+        {% endfor %}
+    // Bring the time step back to the value for the next loop iteration
+    iT++;
+    t = iT*DT;
+        {% if maximum_run_time is not none %}
+    current= std::clock();
+    elapsed_realtime= (double) (current - start)/CLOCKS_PER_SEC;
+    if (elapsed_realtime > {{maximum_run_time}}) {
+      break;
+    }
+        {% endif %}
+  }
+        {% if maximum_run_time is none %}
   current= std::clock();
   elapsed_realtime= (double) (current - start)/CLOCKS_PER_SEC;
-  {% endif %}
+        {% endif %}
   Network::_last_run_time = elapsed_realtime;
   if (duration > 0.0)
   {
-      Network::_last_run_completed_fraction = (t-t_start)/duration;
+    Network::_last_run_completed_fraction = (t-t_start)/duration;
   } else {
-      Network::_last_run_completed_fraction = 1.0;
+    Network::_last_run_completed_fraction = 1.0;
   }
 }
 
 //--------------------------------------------------------------------------
 /*! \brief Method for copying all variables of the last time step from the GPU
- 
+
   This is a simple wrapper for the convenience function copyStateFromDevice() which is provided by GeNN.
 */
 //--------------------------------------------------------------------------
@@ -304,7 +321,7 @@ void engine::getStateFromGPU()
 
 //--------------------------------------------------------------------------
 /*! \brief Method for copying all spikes of the last time step from the GPU
- 
+
   This is a simple wrapper for the convenience function copySpikesFromDevice() which is provided by GeNN.
 */
 //--------------------------------------------------------------------------
@@ -316,6 +333,6 @@ void engine::getSpikesFromGPU()
 
 
 
-#endif	
+#endif
 
 {% endmacro %}


### PR DESCRIPTION
Fixes #139.

In order to maintain my sanity in the template code, I've also cleaned up indentation in templates/engine.cpp prior to implementing slow clock support.
I couldn't see any tests for slow clocks, but I've tested the feature to my satisfaction informally and confirmed locally that there are no regressions (at least as covered by unit tests).