### PR TITLE
Fix repeat runs

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -1258,7 +1258,7 @@ class GeNNDevice(CPPStandaloneDevice):
             combined_override_conditional_write = set()
             has_thresholder = False
 
-            stateupdater_name = obj.name + '_stateupdater'
+            stateupdater_name = None
             slot_mapping = {StateUpdater: 'stateupdate',
                             Thresholder: 'stateupdate',
                             Resetter: 'reset',
@@ -1320,6 +1320,7 @@ class GeNNDevice(CPPStandaloneDevice):
                 combined_abstract_code[code_block] = '\n'.join(combined_abstract_code[code_block])
 
             if any(len(ac) for ac in itervalues(combined_abstract_code)):
+                assert stateupdater_name, 'No StateUpdater found in object.'
                 codeobj = super(GeNNDevice, self).code_object(obj, stateupdater_name,
                                                               combined_abstract_code,
                                                               combined_variables.copy(),


### PR DESCRIPTION
This pull request attempts to fix an issue where the names of StateUpdaters, Thresholders etc. are suffixed with numeric indices, and are therefore not picked up by the hardcoded name checks in process_*_groups.

However, since this fix raises other hidden issues (see below), I can't recommend merging it just yet.