### PR TITLE
Rename `insert_code` slots `run` to `network_run`

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -342,8 +342,8 @@ class GeNNDevice(CPPStandaloneDevice):
         # Overwrite the code slots defined in standard C++ standalone
         self.code_lines = {'before_start': [],
                            'after_start': [],
-                           'before_run': [],
-                           'after_run': [],
+                           'before_network_run': [],
+                           'after_network_run': [],
                            'before_end': [],
                            'after_end': []}
 
@@ -355,7 +355,7 @@ class GeNNDevice(CPPStandaloneDevice):
         ``before_start`` / ``after_start``
             Before/after allocating memory for the arrays and loading arrays from
             disk.
-        ``before_run`` / ``after_run``
+        ``before_network_run`` / ``after_network_run``
             Before/after calling GeNN's ``run`` function.
         ``before_end`` / ``after_end``
             Before/after writing results to disk and deallocating memory.

--- a/brian2genn/templates/main.cpp
+++ b/brian2genn/templates/main.cpp
@@ -129,9 +129,9 @@ int main(int argc, char *argv[])
 
   t= 0.;
   void *devPtr;
-  {{'\n'.join(code_lines['before_run'])|autoindent}}
+  {{'\n'.join(code_lines['before_network_run'])|autoindent}}
   eng.run(totalTime); // run for the full duration
-  {{'\n'.join(code_lines['after_run'])|autoindent}}
+  {{'\n'.join(code_lines['after_network_run'])|autoindent}}
   cerr << t << " done ..." << endl;
   {% if prefs['devices.genn.kernel_timing'] %}
   {% for kt in ('neuronUpdateTime', 'presynapticUpdateTime', 'postsynapticUpdateTime', 'synapseDynamicsTime', 'initTime', 'initSparseTime') %}


### PR DESCRIPTION
This is how the slot is called in brian2 now, see PR brian-team/brian2#1390

Might need changes in the brian2genn_benchmarks repository if those should be run again.