### PR TITLE
Correctly identify cuda_path prefs location

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -1100,7 +1100,7 @@ class GeNNDevice(CPPStandaloneDevice):
                              '"{}"'.format(cuda_path))
             else:
                 raise RuntimeError('Set the CUDA_PATH environment variable or '
-                                   'the devices.genn.cuda_path preference.')
+                                   'the devices.genn.cuda_backend.cuda_path preference.')
 
         with std_silent(debug):
             if os.sys.platform == 'win32':


### PR DESCRIPTION
Apparently the `cuda_path` pref was moved at some point, but the error message related to it wasn't updated. This PR fixes this.