### PR TITLE
fix: check resolved self.kernel_timings instead of stale profile param

### DIFF
--- a/brian2genn/device.py
+++ b/brian2genn/device.py
@@ -1881,7 +1881,7 @@ class GeNNDevice(CPPStandaloneDevice):
         if profile is None:
             self.kernel_timings = self.build_options.pop("profile", None)
             # If not set, check the deprecated preference
-            if profile is None and prefs.devices.genn.kernel_timing:
+            if self.kernel_timings is None and prefs.devices.genn.kernel_timing:
                 logger.warn("The preference 'devices.genn.kernel_timing' is "
                             "deprecated, please set profile=True instead")
                 self.kernel_timings = True


### PR DESCRIPTION
## Summary

Fixes #167

In `GeNNDevice.network_run()`, the deprecated preference fallback on line 1884 checked the original `profile` function parameter instead of the resolved `self.kernel_timings` value after reading from `build_options`. This caused `set_device(..., profile=False)` to be incorrectly overridden by `prefs.devices.genn.kernel_timing = True`.

## Change

```diff
-            if profile is None and prefs.devices.genn.kernel_timing:
+            if self.kernel_timings is None and prefs.devices.genn.kernel_timing:


## Testing
Wrote 8 unit tests that simulate the profile resolution logic in isolation (no GeNN/brian2 required). Tests cover all precedence combinations: explicit `profile` arg, `build_options` values, and deprecated preference fallback. Includes a test that reproduces the exact bug scenario (`build_options=False` + `kernel_timing=True`) and verifies the old logic fails while the fixed logic correctly returns `False`. **All 8 tests passed.**


